### PR TITLE
docs: prepare v0.2.0 release metadata

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,13 @@ TypeScript and JavaScript gates are not applicable; the offline report contains 
   build Mac with Rosetta for dual-architecture execution, the official python.org CPython 3.13.12
   universal2 build Python matching the reviewed release-native profile, a Developer ID Application
   identity, and a configured `notarytool` Keychain profile.
+- The standard python.org installer places the release Python at
+  `/Library/Frameworks/Python.framework/Versions/3.13/bin/python3.13`. Verify the installer signature
+  and published SHA-256 before installation, then prove that executable runs under both `arch
+  -arm64` and `arch -x86_64`; do not substitute Homebrew Python for a distributable build.
+- Configure notarization credentials outside the repository with `notarytool store-credentials` and
+  pass only the resulting Keychain profile name to the release script. Never request, paste, log, or
+  persist an Apple app-specific password in an agent command or environment file.
 - Both DMGs must pass exact-architecture validation, inside-out signing, hardened runtime and sandbox
   entitlement checks, notarization, stapling, Gatekeeper assessment, privacy scanning, license
   collection, exact pre/post-sign native Mach-O license-manifest verification, release-manifest

--- a/docs/release-v0.2.0.md
+++ b/docs/release-v0.2.0.md
@@ -5,9 +5,13 @@ artifact has been published.
 
 ## Current status
 
-As of 2026-07-18:
+As of 2026-07-19:
 
 - source and bundle metadata use version `0.2.0`;
+- the complete synthetic Python and native macOS CI matrix passes on the merged release-candidate
+  source;
+- source-bound wheel and source-distribution builds pass clean-environment installation, dependency,
+  CLI-help, membership, metadata, checksum, and privacy verification locally;
 - the native macOS app has a host-architecture local acceptance path;
 - that local path is sandboxed and ad-hoc signed only;
 - no v0.2.0 release tag is represented as created;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,12 @@ tvtime-extractor = "tvtime_extractor.cli:entrypoint"
 tvtime-extractor-helper = "tvtime_extractor.helper_main:entrypoint"
 
 [project.urls]
+Homepage = "https://github.com/amirbrooks/tvtime-backup-extractor"
 Repository = "https://github.com/amirbrooks/tvtime-backup-extractor"
+Documentation = "https://github.com/amirbrooks/tvtime-backup-extractor#readme"
+Changelog = "https://github.com/amirbrooks/tvtime-backup-extractor/blob/main/CHANGELOG.md"
 Issues = "https://github.com/amirbrooks/tvtime-backup-extractor/issues"
+Security = "https://github.com/amirbrooks/tvtime-backup-extractor/security/policy"
 
 [tool.setuptools.packages.find]
 include = ["tvtime_extractor*"]


### PR DESCRIPTION
## Summary

- publish package discovery, changelog, documentation, and security metadata
- record the current verified v0.2.0 source/CI preparation state without claiming a public binary release
- document the official universal2 Python and secure notarization-profile prerequisites for future release operators

## Validation

- built-in Codex review: clean
- Ruff lint and format: clean
- 257 Python tests with ResourceWarning promoted to errors
- Python build/install, exact hash-lock dependency check, all CLI help screens
- 112 Swift tests in debug and release configurations, optimized Swift build
- complete local macOS app build, signatures, Hardened Runtime, sandbox entitlements, architecture, privacy scan, native license map, helper protocol smoke, and 19-page PDF raster check
- source-bound wheel/sdist built and verified against commit b1886dfa87d3bf8926e89f7dc74101e49c1c15e7 and tree 0bb872b2a91973e1a366bfd920650cf3ca4c4f78

This PR intentionally does not create a tag, claim notarization, or publish v0.2.0 assets. Those remain gated by the configured notary profile and clean-device acceptance contract.