### PR TITLE
docs: record local notarized release readiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,8 +26,10 @@
 - macOS 14+ users receive a native SwiftUI workflow when an architecture-specific signed and
   notarized DMG is published. End users must not need Python, iMazing, Homebrew, Git, or developer
   tools.
-- The current local app build is ad-hoc signed and local-only. No documentation, release note, or UI
-  may imply that a Developer ID-signed, notarized, tagged, or downloadable v0.2.0 artifact exists.
+- `script/build_local_app.sh` remains an ad-hoc, local-only acceptance path. The controlled release
+  pipeline has also produced Developer ID-signed, notarized, stapled local candidates for both
+  architectures, but no documentation, release note, or UI may imply that a tagged, published, or
+  downloadable v0.2.0 artifact exists until the public-release gates are completed.
 - The Python CLI remains the free fallback with Python 3.10 through 3.13. Full encrypted-backup
   recovery is supported on macOS and Linux; Windows supports analysis and report rebuilding from an
   existing completed extraction only in this baseline.
@@ -150,7 +152,8 @@ TypeScript and JavaScript gates are not applicable; the offline report contains 
 ## Release discipline
 
 - Version 0.2.0 is a development baseline until the release checklist is completed. Do not create a
-  tag, upload assets, or change release status based only on a successful local ad-hoc build.
+  tag, upload assets, or claim public availability based only on a successful local build or
+  notarization run.
 - A distributable Mac release requires full Xcode, Swift 6.2-compatible tooling, an Apple Silicon
   build Mac with Rosetta for dual-architecture execution, the official python.org CPython 3.13.12
   universal2 build Python matching the reviewed release-native profile, a Developer ID Application

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes are documented here. The project follows semantic versioning
 
 ## 0.2.0 - Unreleased
 
-Version 0.2.0 is a source and local-acceptance baseline. No v0.2.0 tag, downloadable DMG, or public
-release asset is represented by this entry.
+Version 0.2.0 is a source and local-acceptance baseline. Local Developer ID-signed, notarized,
+stapled Apple silicon and Intel candidates have passed the controlled release pipeline, but no
+v0.2.0 tag, downloadable DMG, or public release asset is represented by this entry.
 
 ### Native macOS application
 
@@ -102,6 +103,10 @@ release asset is represented by this entry.
 - The release pipeline performs no upload and cannot run without a real Developer ID Application
   identity, configured notarization profile, full Xcode, universal2 build Python, and dual-
   architecture execution support.
+- Validated that pipeline locally through signing, notarization, stapling, Gatekeeper,
+  architecture-specific packaged-helper smoke, mounted-DMG license verification, provenance
+  manifests, checksums, and privacy scans for both Apple silicon and Intel candidates. This is local
+  release-preparation evidence, not a claim that v0.2.0 has been tagged or published.
 
 ### Tests and documentation
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,11 @@ human-readable reports plus detailed CSV tables.
 The project is free and open source. iMazing is not required. It does not modify the phone or source
 backup, contact TV Time, restore data to the app, or provide an official cloud-account export.
 
-> **Release status:** the source is at the v0.2.0 development baseline. The macOS application has
-> been built and validated locally with an ad-hoc signature, but there is not yet a downloadable,
-> Developer ID-signed, notarized v0.2.0 public artifact. Do not redistribute the local development
-> app as though it were a release. The currently published v0.1.0 prerelease is CLI-only: its
+> **Release status:** the source is at the v0.2.0 development baseline. The controlled macOS release
+> pipeline has produced and validated local Developer ID-signed, notarized, stapled candidates for
+> Apple silicon and Intel, but there is still no v0.2.0 tag, public release, or downloadable
+> artifact. Do not redistribute a local candidate as though it were published. The currently
+> published v0.1.0 prerelease is CLI-only: its
 > complete Markdown catalogue contains the actual recovered series, movie, favorite, episode, and
 > identifiable watch-event names rather than counts alone. The v0.2.0 source adds the shared offline
 > HTML/PDF views and native macOS result experience. For safety, use v0.1.0 only with Python 3.10

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -3,9 +3,10 @@
 This is a community, best-effort alpha project. It is not affiliated with TV Time or Apple and does
 not provide account recovery, password recovery, data restoration, or legal advice.
 
-The current supported development baseline is source version 0.2.0. A sandboxed native macOS app has
-been validated locally with an ad-hoc signature, but no downloadable, Developer ID-signed, notarized
-v0.2.0 DMG is currently offered. Do not request help bypassing Gatekeeper for an unofficial app.
+The current supported development baseline is source version 0.2.0. The controlled release pipeline
+has validated local Developer ID-signed, notarized, stapled macOS candidates for both architectures,
+but no v0.2.0 tag, public release, or downloadable DMG is currently offered. Do not request help
+bypassing Gatekeeper for an unofficial or locally shared app.
 
 Before opening an issue, read the platform guide, [privacy guide](docs/privacy.md),
 [output reference](docs/output-reference.md), and [troubleshooting guide](docs/troubleshooting.md).

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -4,9 +4,10 @@ The native app is the intended recovery experience for macOS 14 or later. It is 
 recovery engine, and does not require iMazing, Python, Homebrew, Git, GitHub CLI, or developer tools
 for end users.
 
-> **Current distribution status:** no signed and notarized v0.2.0 DMG has been published yet. The
-> app bundle produced by `script/build_local_app.sh` is ad-hoc signed for local development and is
-> not a downloadable public release. Until verified DMGs are published, use the
+> **Current distribution status:** the controlled release pipeline has validated local Developer
+> ID-signed, notarized, stapled DMGs for Apple silicon and Intel, but no v0.2.0 tag, public release,
+> or downloadable artifact exists yet. The app bundle produced by `script/build_local_app.sh`
+> remains ad-hoc signed for contributor use. Until verified DMGs are published, use the
 > [Python CLI fallback](../README.md#python-cli-fallback) or build locally as a contributor.
 
 Contributor app builds use exact CPython 3.13.12 plus a reviewed native-runtime license profile;
@@ -115,9 +116,11 @@ Only follow these installation steps after the project publishes both the artifa
 3. Open the DMG, drag **TV Time Backup Extractor** to **Applications**, then eject the DMG.
 4. Open the installed app from Applications.
 
-A legitimate public package must be Developer ID signed, notarized, stapled, and accepted by
-Gatekeeper. Do not disable Gatekeeper or use an unsigned app downloaded from an issue, message, or
-unofficial mirror. The current local development bundle does not satisfy this distribution contract.
+A legitimate public package must be Developer ID signed, notarized, stapled, accepted by Gatekeeper,
+and downloaded with its published checksum from the official release. Do not disable Gatekeeper or
+use an app from an issue, message, local candidate, or unofficial mirror. The ad-hoc contributor
+bundle does not satisfy this distribution contract, and successful local notarization alone does not
+make a candidate public.
 
 ## 5. Run the guided recovery
 

--- a/docs/release-v0.2.0.md
+++ b/docs/release-v0.2.0.md
@@ -5,18 +5,22 @@ artifact has been published.
 
 ## Current status
 
-As of 2026-07-19:
+As of 2026-07-20:
 
 - source and bundle metadata use version `0.2.0`;
 - the complete synthetic Python and native macOS CI matrix passes on the merged release-candidate
   source;
 - source-bound wheel and source-distribution builds pass clean-environment installation, dependency,
   CLI-help, membership, metadata, checksum, and privacy verification locally;
-- the native macOS app has a host-architecture local acceptance path;
-- that local path is sandboxed and ad-hoc signed only;
+- the host-architecture contributor acceptance path remains sandboxed and ad-hoc signed;
+- the controlled dual-architecture release pipeline has also produced local Developer ID-signed,
+  notarized, stapled Apple silicon and Intel DMGs from reviewed source;
+- both local DMGs passed exact-architecture, hardened-runtime, sandbox-entitlement, Gatekeeper,
+  packaged-helper synthetic-preflight, native-license, manifest, checksum, and privacy gates;
 - no v0.2.0 release tag is represented as created;
 - no v0.2.0 DMG, release manifest, or checksum file is represented as published; and
-- no Developer ID signing or Apple notarization result is claimed.
+- clean-device installation, authorized private real-backup acceptance, draft-asset re-download,
+  and public-release approval remain outstanding distribution gates.
 
 The README and platform guides must keep this state visible until every gate below is completed and
 the distribution state is updated deliberately.


### PR DESCRIPTION
## Summary
- record successful local Developer ID signing, notarization, stapling, Gatekeeper, architecture, license, manifest, checksum, and privacy validation for both macOS architectures
- preserve the unpublished boundary: no v0.2.0 tag, official download, or public release is claimed
- keep clean-device, authorized private real-backup, draft re-download, and public approval gates explicit

## Validation
- Ruff and formatting: passed
- Python suite: 261 passed, 1 skipped
- Swift debug/release suites: 112 passed in each configuration
- Swift release build and shell syntax: passed
- full tracked-source privacy scan: passed

No tag or release asset upload is included.