### PR TITLE
feat: add native Windows recovery and Refract conversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
           tvtime-extractor analyze --help
           tvtime-extractor report --help
 
-  windows-existing-extraction:
-    name: Windows existing-extraction Python ${{ matrix.python-version }}
+  windows-recovery:
+    name: Windows full recovery Python ${{ matrix.python-version }}
     runs-on: windows-latest
     strategy:
       fail-fast: false
@@ -74,16 +74,9 @@ jobs:
         run: "python -m pip install --require-hashes --only-binary=:all: --requirement requirements-dev.lock"
       - name: Verify the installed dependency graph
         run: python -m pip check
-      - name: Test only supported Windows existing-extraction and fail-closed contracts
-        run: >-
-          python -m unittest -v
-          tests.test_analyze_report
-          tests.test_analysis_bounds_and_labels
-          tests.test_cancellation_and_reports
-          tests.test_recovery_output_validator
-          tests.test_safety.WindowsDirectoryHandleContractTests
-          tests.test_cli.CliTests.test_debug_help_warns_that_tracebacks_can_expose_secrets_and_must_not_be_shared
-      - name: Check installed review commands and documented refusal commands
+      - name: Run the complete synthetic Windows suite
+        run: python -m unittest discover -s tests -v
+      - name: Check installed recovery and review commands
         run: |
           tvtime-extractor --help
           tvtime-extractor recover --help

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes are documented here. The project follows semantic versioning.
 
+## Unreleased
+
+- Added a Windows 11 x64 native filesystem capability backend. It atomically creates a fresh NTFS
+  output root with `NtCreateFile`, applies and verifies a protected current-user-and-SYSTEM ACL,
+  holds source/output identities without delete sharing, rejects reparse traversal, and promotes
+  held files without replacement.
+- Added repository-owned descriptor decryption for the manifest and selected payloads, strict CBC
+  padding validation, explicit declared-size discrepancy recording, immutable read-only SQLite
+  manifest access, and held retained-manifest promotion. The path-only dependency plaintext writers
+  are no longer used.
+- Enabled Windows CLI `recover` and `extract`, including opt-in retained manifests, while retaining
+  fail-closed checks for unsupported Windows versions, architectures, filesystems, ACLs, and paths.
+- Added synthetic Windows NTFS, cryptographic boundary, collision, ACL, handle-locking, source
+  binding, full recovery, analysis, and report coverage. This source work is not a published release.
+- Added fixed, content-free categories to private selected-file failure rows while keeping terminal
+  output, public JSON, exit codes, completion markers, and successful-output contracts unchanged.
+- Restored compatible selected-file size warnings: valid padded plaintext is retained at its actual
+  length, discrepancies stay explicit, and full recovery still requires SQLite integrity checks.
+- Added an offline, Windows-friendly converter and private handling guide for turning recovered
+  series, cached episode, and favorite analysis tables into a TV-Time-Out/Refract series JSON. It
+  uses bounded no-follow input reads, recorded CSV escape metadata, fresh private output, and atomic
+  no-replace promotion without inventing missing episode history.
+
 ## 0.2.0 - 2026-07-20
 
 Version 0.2.0 is published with Developer ID-signed, notarized, stapled Apple silicon and Intel

--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ backup, contact TV Time, restore data to the app, or provide an official cloud-a
 > HTML/PDF views, and native macOS recovery experience. The Python CLI supports Python 3.10 through
 > 3.13; on Windows, use only `analyze` or `report` with an already completed extraction.
 
+The current unreleased source tree adds full Windows 11 x64 CLI recovery on local NTFS storage. It
+has not been published as a later release; Windows users evaluating the source implementation must
+follow the [Windows guide](docs/windows.md) and its BitLocker/private-storage requirements.
+
 This project is independent and is not affiliated with or endorsed by TV Time or Apple. TV Time and
 related marks belong to their respective owners. Use it only with data you own or are authorized to
 access, and comply with applicable law and service terms.
@@ -24,8 +28,8 @@ access, and comply with applicable law and service terms.
 | Route | Best for | Requirements |
 | --- | --- | --- |
 | Native macOS app | Most Mac users | macOS 14 or later and the v0.2.0 DMG matching the Mac's architecture |
-| Python CLI recovery | macOS, Linux, automation, and development | An explicitly selected Python 3.10 through 3.13 plus the pinned dependencies |
-| Windows existing-extraction tools | Windows review of an already complete extraction | Python 3.10 through 3.13; fresh `extract` and `recover` fail closed |
+| Python CLI recovery | macOS, Linux, Windows 11 x64, automation, and development | An explicitly selected Python 3.10 through 3.13 plus the pinned dependencies |
+| Windows CLI recovery | Windows 11 x64 source candidate | 64-bit Python, local NTFS private output, and BitLocker or equivalent encryption |
 
 The published native app is the normal Mac installation:
 
@@ -86,7 +90,7 @@ The completed native result screen provides:
 - a verified-package panel confirming selected source stability, completion-marker consistency,
   copied-file integrity, and sealed report artifacts;
 - an aggregate bar chart and explicit watched/saved movie and named/unnamed event counts;
-- copied-file and byte-count-difference summaries;
+- copied-file summaries and fail-closed declared-size validation;
 - aggregate image, trailer, and media-URL reference counts;
 - a visual report, print-friendly PDF, and complete Markdown catalogue, with a clear explanation
   when the optional PDF is omitted; and
@@ -193,13 +197,21 @@ new one if the project moves.
 
 Use an individual backup folder and a destination run path that does not yet exist. The immediate
 encrypted output parent must already exist; the fresh run child itself must not exist. This
-parent-exists/child-does-not rule also applies when selecting paths on Windows, although Windows
-fresh recovery is refused in this release. On macOS or Linux:
+parent-exists/child-does-not rule applies on every supported platform. On macOS or Linux:
 
 ```text
 ./.venv/bin/python -m tvtime_extractor recover \
   --backup "/path/to/DEVICE_BACKUP" \
   --output "/path/to/PRIVATE_NEW_RUN" \
+  --acknowledge-sensitive-output
+```
+
+On supported Windows source builds, use Windows paths and PowerShell line continuations:
+
+```powershell
+.venv\Scripts\python.exe -m tvtime_extractor recover `
+  --backup "C:\Synthetic\DEVICE_BACKUP" `
+  --output "D:\Private\NEW_RUN" `
   --acknowledge-sensitive-output
 ```
 
@@ -215,9 +227,10 @@ in the command,
 environment, shell history, or a support request. The default terminal output is a concise readable
 summary; `--json` is an explicit private automation option and is not the default.
 
-On Windows, move or copy the intact encrypted backup to a private macOS/Linux system for extraction,
-or bring an already complete private extraction to Windows and use only `analyze`/`report`; see the
-[Windows guide](docs/windows.md).
+Windows recovery requires Windows 11 x64, 64-bit Python, and a local NTFS destination outside cloud
+sync, network, WSL, and reparse paths. BitLocker or equivalent encryption remains a user-verified
+requirement; see the [Windows guide](docs/windows.md). The published v0.2.0 packages still predate
+this source implementation.
 
 Linux accepts only a conservative set of ordinary local filesystem types. FUSE, network, shared,
 virtual-machine shared-folder, temporary, overlay, and unknown filesystem types are refused with no
@@ -257,6 +270,7 @@ backup until titles, favorites, episodes, watch events, and completion markers h
 - [macOS guide](docs/macos.md)
 - [Windows guide](docs/windows.md)
 - [Linux guide](docs/linux.md)
+- [Refract series import guide for Windows](docs/refract-import.md)
 - [Privacy and safe handling](docs/privacy.md)
 - [Output reference](docs/output-reference.md)
 - [Troubleshooting](docs/troubleshooting.md)

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -9,6 +9,11 @@ Developer ID-signed, notarized, stapled macOS DMGs for Apple silicon and Intel, 
 packages. Download only from the official release, verify `SHA256SUMS`, and do not request help
 bypassing Gatekeeper for an unofficial or locally shared app.
 
+The current unreleased source tree contains a Windows 11 x64 CLI recovery backend. It is not part
+of the published v0.2.0 contract and must complete the full release checklist before it can be
+described as a distributed Windows release. Source evaluators should follow `docs/windows.md` and
+use only local NTFS private output protected by BitLocker or equivalent encryption.
+
 Before opening an issue, read the platform guide, [privacy guide](docs/privacy.md),
 [output reference](docs/output-reference.md), and [troubleshooting guide](docs/troubleshooting.md).
 Search existing issues without pasting private data.
@@ -16,7 +21,7 @@ Search existing issues without pasting private data.
 A safe support request may include:
 
 - application or `tvtime-extractor --version` output;
-- operating system and Mac architecture, or Python version for CLI use;
+- operating system and architecture, plus Python version for CLI use;
 - the workflow stage or CLI subcommand and exit code;
 - whether the expected extraction/report completion marker was absent, incomplete, or complete,
   without attaching the marker;

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -159,7 +159,7 @@ the successful result available rather than treating it as cancelled.
 The success screen appears only after the app reopens and validates the completed package. It shows
 the selected-source, completion-marker, copied-file, and sealed-artifact checks together with an
 aggregate chart, separate watched/saved movie and named/unnamed event counts, copied-file totals,
-byte-count differences, and aggregate media-reference counts. Validate those counts before opening
+strict declared-size validation, and aggregate media-reference counts. Validate those counts before opening
 private reports.
 
 The app offers:

--- a/docs/output-reference.md
+++ b/docs/output-reference.md
@@ -46,6 +46,27 @@ it is not silently deduplicated by title. The readable report separately shows n
 records and the number of distinct named series titles. Synthetic QA fixtures use arbitrary record
 counts to exercise pagination and must not be compared with a real recovery.
 
+## Private extraction failure categories
+
+When one selected backup file cannot be copied, its private `metadata/summary.json` failure row
+retains the generic `error` text and adds one fixed `category` value:
+
+- `invalid_manifest_metadata`, `unsafe_path`, `source_unavailable`, or `source_changed`;
+- `missing_encryption_key` or `key_unwrap_failure`;
+- `ciphertext_invalid`, `padding_failure`, or `size_mismatch`; or
+- `staging_failure`, `promotion_failure`, or `unrecognized_failure`.
+
+These identifiers describe only the failed processing stage. They never contain exception text,
+operating-system errors, keys, hashes, sizes, or recovered content. The surrounding row still
+contains private backup identifiers and paths, so never attach, quote, upload, or paste the failure
+inventory. Normal terminal and `--json` summaries expose only the total failure count.
+
+A selected payload that has valid ciphertext, a valid key, and valid PKCS#7 padding is not a copy
+failure solely because its recovered length differs from the manifest declaration. The exact
+declared and actual lengths are retained privately in `size_discrepancies`; terminal and public JSON
+output expose only the warning count. The `size_mismatch` failure identifier remains part of the
+fixed internal vocabulary for exact-length decryption contexts and older incomplete summaries.
+
 ## Human-readable reports
 
 All three formats are generated from the same shared safe display model:

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -34,14 +34,16 @@ replacing the backup root or changing bound critical metadata or a displayed agg
 confirmation fails before output creation. Selected payload files are snapshot-verified during
 extraction and revalidated before extraction completion. The POSIX CLI consumes the same
 identity-bound receipt across its hidden password prompt and applies the same held-parent and
-held-output-root model. Windows fresh extraction and recovery fail closed because the supported
-Python APIs cannot atomically create and lock a new plaintext directory. There is no override.
-Windows standalone analysis and reporting can hold an already complete extraction root without
-delete sharing, reject reparse points, and require the same volume/file identity to remain visible
-at completion. These checks do not make a mounted plaintext destination encrypted or prove that
-custom sync is disabled. The full-recovery CLI cannot certify every storage stack and therefore
-requires an explicit encrypted-destination acknowledgement. Neither interface can certify ownership
-authorization, sync behavior, snapshots, or backup policy; the user must confirm those boundaries.
+held-output-root model. On supported Windows 11 x64 source builds, `NtCreateFile` atomically creates
+the fresh child relative to the held parent, applies a protected current-user-and-SYSTEM ACL, and
+returns the handle in the same operation. Windows keeps the source, parent, and output handles open
+without delete sharing, rejects reparse traversal, writes through exclusive descriptors, and
+revalidates native identities and visible paths. Unsupported Windows capabilities fail before
+password entry or plaintext creation. These checks do not make a mounted plaintext destination
+encrypted or prove that custom sync is disabled. The full-recovery CLI cannot certify BitLocker or
+every storage stack and therefore requires an explicit encrypted-destination acknowledgement.
+Neither interface can certify ownership authorization, sync behavior, snapshots, or backup policy;
+the user must confirm those boundaries.
 
 Linux FUSE destinations are refused because the same mechanism can expose local, network, cloud, or
 shared storage. There is no override. Linux accepts only a conservative allowlist of ordinary local

--- a/docs/refract-import.md
+++ b/docs/refract-import.md
@@ -1,0 +1,117 @@
+# Import recovered series into Refract on Windows
+
+The repository includes an offline converter for the JSON series format produced by
+[TV-Time-Out](https://github.com/jeremyndeby/TV-Time-Out). Its exporter writes followed shows as a
+top-level JSON array in `tvtime-series-{date}.json`, with seasons and episodes nested below each
+show. The converter reproduces that shape from this extractor's private analysis tables; it does
+not contact TV Time, Refract, TVDB, or any other network service.
+
+This is a best-effort conversion of recovered local cache data. The cache may not contain every
+episode. Missing episodes, watch dates, identifiers, or rewatches are never invented.
+
+## Private inputs
+
+Use the `analysis` directory from one completed extraction. The converter reads:
+
+- `series_library.csv` and `analysis_summary.json` (required);
+- `episode_cache_unique.csv` (recommended, for recovered episode state); and
+- `favorite_shows.csv` (optional, for favorite flags).
+
+Do not move these files into this Git repository or send them to an online CSV converter. They can
+contain private titles, identifiers, and viewing history. Keep both the extraction and converted
+JSON on local BitLocker-protected or equivalent private storage outside cloud-sync folders.
+
+## Convert with PowerShell
+
+Run these commands from the repository root. Substitute the first path with your completed private
+analysis directory. The `Refract-Imports` parent may be created in advance, but the final
+`Refract-Series-NEW` directory must not exist: the converter creates it privately and refuses to
+overwrite or merge output.
+
+```powershell
+New-Item -ItemType Directory -Force "C:\Private\Refract-Imports"
+
+.venv\Scripts\python.exe script\convert_refract_series.py `
+  --analysis "C:\Private\TVTime-Extraction\analysis" `
+  --output "C:\Private\Refract-Imports\Refract-Series-NEW"
+```
+
+Using `C:\` is supported when the destination is a local NTFS volume and the selected path is not a
+reparse point, cloud-sync location, network share, or Git repository. Choose another new child name
+if a previous attempt already created `Refract-Series-NEW`.
+
+On success, the new directory contains exactly one file named like:
+
+```text
+tvtime-series-2026-07-23.json
+```
+
+The normal terminal summary contains aggregate counts only. It does not print series titles,
+identifiers, private paths, or recovered content.
+
+## How fields are converted
+
+Each `series_library.csv` row becomes one show:
+
+| Extractor field | TV-Time-Out/Refract field |
+| --- | --- |
+| `uuid` | `uuid` |
+| `series_id` | `id.tvdb` as an integer |
+| unavailable | `id.imdb: null` |
+| `created_at` | `created_at`, or `null` when blank |
+| `name` | `title` |
+| selected completion policy | `status: "up_to_date"` |
+| matching `favorite_shows.id` | `is_favorite` |
+
+`up_to_date` is the completion-like value emitted by
+[TV-Time-Out's show normalization](https://github.com/jeremyndeby/TV-Time-Out/blob/main/background.js#L1057-L1086).
+It does not mark nonexistent episodes as watched.
+
+Episode rows are joined only when `episode_cache_unique.csv.show_id` exactly matches a converted
+`series_id`. Seasons and episodes are sorted numerically. Season zero is marked as specials; `TBA`
+placeholders are omitted. `seen`, `is_watched`, or a valid `seen_date` supplies watched evidence.
+Valid dates are normalized to UTC as `YYYY-MM-DDTHH:MM:SSZ`.
+
+The recovered cache does not provide a reliable rewatch ledger, so `rewatch_count` is zero and
+`watched_count` is either zero or one. A series with no usable episode rows receives `seasons: []`
+and `_noEpisodeData: true`. Its show status remains `up_to_date`, but no episode watch is fabricated.
+The show-level `last_watch_date` is never assigned to an arbitrary episode.
+
+The analyzer protects spreadsheet-sensitive text by adding a leading apostrophe in CSV. The
+converter reads `analysis_summary.json` and removes that apostrophe only at the exact recorded cell
+coordinates, preserving genuine leading apostrophes.
+
+## Validate and import
+
+Replace the date below with the generated filename date:
+
+```powershell
+.venv\Scripts\python.exe -m json.tool `
+  "C:\Private\Refract-Imports\Refract-Series-NEW\tvtime-series-2026-07-23.json" `
+  > $null
+```
+
+No output means Python accepted the JSON syntax. You can also confirm that the directory contains
+only that one JSON file:
+
+```powershell
+Get-ChildItem -LiteralPath "C:\Private\Refract-Imports\Refract-Series-NEW" -Force
+```
+
+In Refract, choose the TV Time import and select only the generated `tvtime-series-{date}.json`.
+Review Refract's completion summary before keeping the import. This action intentionally transfers
+the converted private viewing data to Refract; the offline converter itself transfers nothing.
+
+## Failure behavior
+
+- Invalid or duplicate series IDs, malformed headers, invalid summary JSON, unsafe paths, and output
+  collisions stop the conversion.
+- Parsing and schema validation finish before the output directory is created.
+- Unmatched episode and favorite rows are omitted and reported only as aggregate counts.
+- Missing optional companion tables produce shows with empty seasons or non-favorite status.
+- An incomplete staging file is never promoted as the Refract JSON.
+- Movies and custom lists are outside this converter's scope.
+
+The upstream exporter creates only the non-empty artifact types available for a run; its JSON file
+selection is implemented in
+[`buildFilesList`](https://github.com/jeremyndeby/TV-Time-Out/blob/main/exporter.js#L1097-L1108).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -106,7 +106,7 @@ The extractor refuses a destination that:
 - is or traverses an unsafe symbolic link or reparse point; or
 - is on a nonlocal volume, is an ubiquitous item, is under a known cloud/File Provider or shared
   root, or uses FUSE, an unknown filesystem, or an ambiguous stacked Linux mount; or
-- does not have a safe existing immediate parent (required by the POSIX CLI's held-directory check).
+- does not have a safe existing immediate parent (required by every CLI recovery backend).
 
 The native macOS app prepares a new owner-only child in its private local container automatically;
 start over so it can recheck that location. The CLI still requires a new child path on private
@@ -116,6 +116,11 @@ On Linux, FUSE, network, shared-folder, overlay, temporary, unknown, and ambiguo
 are refused with no override. Use a directly mounted, locally encrypted filesystem supported by the
 [Linux guide](linux.md#destination-filesystem-checks). Do not share `mountinfo` or mount-command
 output; it can contain private paths.
+
+On Windows, recovery additionally requires Windows 11 x64, 64-bit Python, local NTFS with persistent
+ACLs, and a non-reparse destination outside UNC, network, cloud-sync, and WSL paths. ReFS, FAT, and
+exFAT are refused. Use BitLocker or equivalent private storage; the CLI cannot certify BitLocker
+state automatically. See the [Windows guide](windows.md).
 
 ## The app says there is not enough free space
 
@@ -143,6 +148,9 @@ ls -lh "$BACKUP/Manifest.db"
 df -h "/path/to/private/destination-parent"
 ```
 
+On Windows, use private local properties dialogs to inspect free space. Do not paste filesystem or
+volume output into a support request because it can expose private paths and labels.
+
 After a disk-full failure, preserve the partial run privately, free space without touching the
 backup, and retry into a new output folder.
 
@@ -169,7 +177,10 @@ not become a cancellation.
 ## Extraction stopped or finished with copy failures
 
 Analysis does not proceed when a selected file could not be copied. The private
-`metadata/summary.json` records the failure inventory. Do not attach or quote it in an issue.
+`metadata/summary.json` records the failure inventory. Each row has a fixed content-free `category`
+such as `missing_encryption_key`, `key_unwrap_failure`, `ciphertext_invalid`, or `padding_failure`.
+Categories identify the processing stage without recording the underlying exception, but the rest
+of each row remains private. Do not attach, quote, upload, or paste the inventory in an issue.
 
 Every started extraction has `metadata/run_state.json`, initially marked `incomplete`. It becomes
 `complete` only after source revalidation and safe extraction cleanup. A wrong password,
@@ -192,16 +203,18 @@ hand. Retry into a new destination.
 Standalone `extract` intentionally produces only `run_state.json`; it does not constitute a full
 recovery report.
 
-## The result reports byte-count differences
+## Extraction reports a declared-size warning
 
-The decryption dependency can return a file length different from the length declared in backup
-metadata. The extractor records every mismatch privately, suppresses dependency output that could
-expose absolute paths, and continues only when every selected file was copied. The analyzer then
-requires the primary recovered database to pass SQLite integrity checks.
+After valid CBC decryption and strict PKCS#7 padding validation, the recovered byte count can differ
+from the size declared in backup metadata. The extractor preserves the complete recovered bytes,
+records the difference privately, and reports only the warning count in terminal and public JSON
+output. It does not truncate or extend the file to force a match. Dependency output that could
+expose absolute paths remains suppressed.
 
-Keep the source and output. Validate the readable titles and counts, copied-file total, completion
-markers, and private discrepancy records. A difference is an explicit salvage warning: it is neither
-silently discarded nor automatically proof of an unusable recovery.
+Full recovery continues through the normal schema and SQLite integrity checks. If the required
+database is not structurally usable, analysis fails and the full recovery remains incomplete. Keep
+all warning details and recovered files private; the discrepancy rows contain paths and exact sizes
+and must not be pasted into an issue.
 
 ## The PDF was not created
 

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -1,18 +1,29 @@
 # Windows guide
 
-Windows can create the encrypted Apple backup and can inspect an already complete private
-extraction. Fresh `extract` and `recover` are deliberately unsupported in this release. iMazing is
-not required.
+The current source tree supports full command-line recovery on Windows 11 x64 with 64-bit Python
+3.10 through 3.13. The published v0.2.0 packages predate this work and still support only
+`analyze` and `report` on Windows; do not treat a local source checkout as a published Windows
+release. iMazing is not required.
 
-## 1. Make a completed encrypted backup
+## 1. Requirements
 
-Use Apple Devices on current Windows systems, or iTunes where Apple Devices is unavailable.
-Connect the iPhone or iPad, select a local backup, enable backup encryption, choose and save a unique
-password, and wait for the latest-backup time to update. Confirm the completed backup appears as
-encrypted in Apple's backup-management screen.
+- Windows 11 on x64 with 64-bit Python 3.10, 3.11, 3.12, or 3.13.
+- A completed encrypted backup created by Apple Devices or iTunes.
+- A local NTFS output volume with persistent ACL support. ReFS, FAT, exFAT, UNC/network paths,
+  cloud-sync roots, WSL paths, and reparse-point destinations are rejected.
+- A private destination protected by BitLocker or equivalent full-volume encryption. The tool
+  cannot reliably verify BitLocker state, so the sensitive-output acknowledgement remains required.
+- The immediate output parent must already exist and the selected run child must not exist.
 
-Eject the device in Apple software, wait for it to disappear, and disconnect it. Do not move,
-rename, edit, or clean the backup while Apple software is using it.
+Windows ARM64, 32-bit Python, Windows 10, containers, WSL recovery, and a native Windows GUI are not
+supported by this initial backend.
+
+## 2. Make and locate a completed encrypted backup
+
+In Apple Devices, select a local backup, enable backup encryption, save its password, and wait for
+the latest-backup time to update. Confirm the backup appears as encrypted, eject the device in Apple
+software, wait for it to disappear, and disconnect it. Do not move, rename, edit, or clean the
+backup while Apple software is using it.
 
 Common backup-parent locations are:
 
@@ -21,38 +32,34 @@ Common backup-parent locations are:
 %APPDATA%\Apple Computer\MobileSync\Backup
 ```
 
-The individual backup is the child folder that directly contains `Manifest.plist`, `Manifest.db`,
-and `Status.plist`, not the parent `Backup` folder.
+Select the individual child folder that directly contains `Manifest.plist`, `Manifest.db`, and
+`Status.plist`, not the parent `Backup` folder.
 
-## 2. Why Windows fresh recovery fails closed
+## 3. Why native Windows recovery is now possible
 
-Recovery must create a brand-new directory and bind that exact filesystem object before any
-plaintext can be written. Python's supported Windows APIs cannot atomically create a directory and
-open its protective non-delete-sharing handle. Creating by pathname and opening afterward leaves a
-substitution interval, so this release refuses Windows `extract` and `recover` before creating the
-run directory, loading the decryption dependency, or writing plaintext.
+The earlier limitation correctly described `CreateDirectoryW`: it creates a directory but does not
+return a handle, so opening it afterward leaves a substitution interval. The new backend does not
+use that two-step sequence. It calls the documented Windows `NtCreateFile` API with `FILE_CREATE`,
+`FILE_DIRECTORY_FILE`, `FILE_OPEN_REPARSE_POINT`, and the already-held parent as `RootDirectory`.
+That one operation creates the fresh directory, applies a protected ACL, and returns its handle.
 
-There is no unsafe override. A future Windows recovery path requires a reviewed native atomic design.
-The package therefore does not advertise a general Windows operating-system classifier.
+The backend then keeps the source root, destination parent, and output root open without delete
+sharing; creates descendants relative to those handles; rejects reparse components; decrypts into
+exclusive held staging descriptors; and atomically promotes completed files with
+`SetFileInformationByHandle`. It validates native volume/file identities and the visible paths
+before and after recovery. The protected output ACL grants full control only to the current user and
+SYSTEM.
 
-## 3. Safe recovery route
+Capability checks run before password entry. Unsupported Windows versions, architectures,
+filesystems, ACLs, paths, or unavailable native APIs fail before plaintext creation.
 
-Copy the intact encrypted backup to private storage on macOS or Linux and run recovery there. Keep
-the original encrypted backup until the result is validated. If transferring a completed extraction
-back to Windows, protect it with BitLocker and treat every title and history row as private.
+## 4. Install from this source checkout
 
-For any fresh run path, the encrypted immediate parent must already exist and the proposed run child
-must not exist. This parent-exists/child-does-not rule applies on every platform; it does not enable
-Windows fresh recovery.
+Install an explicitly selected 64-bit Python 3.10 through 3.13 from python.org or another trusted
+managed source. From the project folder in PowerShell:
 
-## 4. Install the supported Windows review tools
-
-Install an explicitly selected Python 3.10 through 3.13 from python.org or another trusted managed
-source. The examples prefer 3.13 so `py` cannot silently select unsupported Python 3.14. From the
-project folder in PowerShell:
-
-```text
-py -3.13 -m venv .venv
+```powershell
+py -3.12 -m venv .venv
 .venv\Scripts\python.exe -m pip install --require-hashes --only-binary=:all: --requirement requirements.lock
 .venv\Scripts\python.exe -m pip install --require-hashes --only-binary=:all: --requirement requirements-source-build.lock
 .venv\Scripts\python.exe -m pip install --no-index --no-build-isolation --no-deps .
@@ -60,34 +67,55 @@ py -3.13 -m venv .venv
 .venv\Scripts\python.exe -m tvtime_extractor --version
 ```
 
-You may substitute an explicit `py -3.10`, `-3.11`, or `-3.12`. Do not use an unqualified `py -3`
-when it could select 3.14.
+You may substitute an explicit `py -3.10`, `-3.11`, or `-3.13`. Do not use an unqualified `py -3`
+when it could select unsupported Python 3.14. Confirm the selected interpreter is 64-bit:
 
-## 5. Analyze or report an existing complete extraction
+```powershell
+.venv\Scripts\python.exe -c "import struct; print(struct.calcsize('P') * 8)"
+```
 
-Use only an extraction that already has a valid complete extraction marker:
+The result must be `64`.
 
-```text
+## 5. Run recovery
+
+Create a private parent on a BitLocker-protected local NTFS volume. Choose a new child name that
+does not exist, then run:
+
+```powershell
+.venv\Scripts\python.exe -m tvtime_extractor recover `
+  --backup "C:\Synthetic\DEVICE_BACKUP" `
+  --output "D:\Private\NEW_RUN" `
+  --acknowledge-sensitive-output
+```
+
+The CLI completes preflight before prompting securely for the backup password. Keep Apple Devices
+and iTunes closed and do not reconnect the phone during recovery. `extract` has the same Windows
+support, including the advanced `--include-decrypted-manifest` option; retained manifests are
+especially sensitive and remain opt-in.
+
+Do not put the password in the command, an environment variable, shell history, or a support
+request. An interrupted or failed run remains private and marked incomplete; retry into a different
+fresh child instead of reusing it.
+
+## 6. Analyze or rebuild reports
+
+Successful `recover` already runs analysis and reporting. The standalone commands remain available
+for a completed extraction:
+
+```powershell
 .venv\Scripts\python.exe -m tvtime_extractor analyze --extraction "D:\Private\TVTime-Extraction"
 .venv\Scripts\python.exe -m tvtime_extractor report --extraction "D:\Private\TVTime-Extraction"
 ```
 
-These standalone commands open the selected existing root without delete sharing, reject reparse
-points, compare its volume/file identity with the visible path, keep the handle open, and validate
-the identity again at completion. They never unlock an iOS backup.
+Opening private reports can add their filenames to browser or viewer history and Windows Recent
+Items. Close those windows after validation and keep the output off cloud-sync and shared storage.
 
-Running `extract` or `recover` on Windows returns a fixed unsupported-platform error. It must not
-prompt for the password or create the proposed output child.
+## 7. Private diagnostics
 
-## 6. Private diagnostics and validation
-
-The normal CLI error is deliberately sanitized. `--debug` can expose backup paths, dependency
-details, recovered names, or password text in a chained third-party exception. Use it only in a
-private local terminal and never paste or share its traceback.
-
-For an existing complete extraction, confirm both `metadata\run_state.json` and
-`analysis\recovery_state.json` say `complete`. Never upload the extraction, reports, screenshots, or
-debug output.
+Normal CLI errors are deliberately sanitized. `--debug` can expose paths, dependency details,
+recovered names, or password text in a chained exception. Use it only in a private local terminal
+and never paste or share its traceback. Never upload a backup, extraction, report, database,
+completion marker, screenshot, or recovered title list.
 
 See the [output reference](output-reference.md), [privacy guide](privacy.md), and
 [troubleshooting guide](troubleshooting.md).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",
   "Operating System :: MacOS",
+  "Operating System :: Microsoft :: Windows :: Windows 11",
   "Operating System :: POSIX :: Linux",
   "Programming Language :: Python :: 3",
   "Programming Language :: Python :: 3 :: Only",

--- a/script/convert_refract_series.py
+++ b/script/convert_refract_series.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from tvtime_extractor.errors import OutputExistsError, TVTimeError, UnsafePathError  # noqa: E402
+from tvtime_extractor.refract import (  # noqa: E402
+    RefractConversionError,
+    convert_refract_series,
+)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Convert a private TV Time analysis directory into a Refract-compatible series JSON "
+            "without using the network."
+        )
+    )
+    parser.add_argument(
+        "--analysis",
+        required=True,
+        type=Path,
+        help="Private analysis directory containing series_library.csv.",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        type=Path,
+        help="New private output directory; its immediate parent must already exist.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    arguments = build_parser().parse_args(argv)
+    try:
+        result = convert_refract_series(
+            analysis_directory=arguments.analysis,
+            output_directory=arguments.output,
+        )
+    except OutputExistsError:
+        print(
+            "[tvtime-refract] The output already exists. Choose a new private directory.",
+            file=sys.stderr,
+        )
+        return 2
+    except UnsafePathError:
+        print(
+            "[tvtime-refract] The input or output did not meet the private local path "
+            "requirements.",
+            file=sys.stderr,
+        )
+        return 2
+    except RefractConversionError as exc:
+        print(f"[tvtime-refract] {exc}", file=sys.stderr)
+        return 2
+    except TVTimeError:
+        print("[tvtime-refract] The conversion could not be completed safely.", file=sys.stderr)
+        return 1
+    except Exception:
+        print("[tvtime-refract] The conversion failed safely.", file=sys.stderr)
+        return 1
+
+    stats = result.stats
+    print(
+        f"[tvtime-refract] Converted {stats.series} series and {stats.episodes} recovered episodes."
+    )
+    print(
+        f"[tvtime-refract] Ignored {stats.unmatched_episode_rows} unmatched episode rows, "
+        f"{stats.ignored_episode_rows} unusable episode rows, and "
+        f"{stats.unmatched_favorite_rows} unmatched favorite rows."
+    )
+    print("[tvtime-refract] Refract series JSON created successfully.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_analyzer_nofollow.py
+++ b/tests/test_analyzer_nofollow.py
@@ -21,6 +21,7 @@ from tvtime_extractor.safety import (
 
 
 class AnalyzerNoFollowTests(unittest.TestCase):
+    @unittest.skipIf(os.name == "nt", "Windows held readers deny visible replacement")
     def test_plist_parse_uses_one_held_identity_across_a_visible_swap_restore(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -89,6 +90,7 @@ class AnalyzerNoFollowTests(unittest.TestCase):
             self.assertEqual(plistlib.loads(bytes(held_payload)), {"SyntheticFeatureEnabled": True})
             self.assertFalse((extraction / "analysis").exists())
 
+    @unittest.skipIf(os.name == "nt", "Windows held readers deny visible replacement")
     def test_sqlite_snapshot_rejects_boundary_swap_even_when_path_is_restored(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)
@@ -217,6 +219,7 @@ class AnalyzerNoFollowTests(unittest.TestCase):
             plist_loads.assert_not_called()
             self.assertFalse((extraction / "analysis").exists())
 
+    @unittest.skipIf(os.name == "nt", "Windows uses native CreateFile rather than os.open")
     def test_bounded_binary_readers_reject_preopen_replacement(self) -> None:
         readers = {
             "complete": lambda path: read_regular_bytes(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,9 @@ import io
 import json
 import os
 import shutil
+import sqlite3
 import stat
+import struct
 import subprocess
 import sys
 import tempfile
@@ -62,7 +64,7 @@ class _FakeKeybag:
     def unwrapKeyForClass(self, protection_class: object, encryption_key: object) -> bytes:
         if protection_class != 1 or encryption_key != b"wrapped-key":
             raise AssertionError("Unexpected synthetic key metadata")
-        return b"unwrapped-key"
+        return b"K" * 32
 
 
 class _FakeFilePlist:
@@ -71,14 +73,6 @@ class _FakeFilePlist:
         self.encryption_key = value["encryption_key"]
         self.protection_class = value["protection_class"]
         self.mtime = value["mtime"]
-
-
-class _FakeConnection:
-    def __init__(self) -> None:
-        self.closed = False
-
-    def close(self) -> None:
-        self.closed = True
 
 
 class _FakeBackup:
@@ -102,8 +96,10 @@ class _FakeBackup:
         self._manifest_plist = {"synthetic": True}
         self._temporary_folder = tempfile.mkdtemp(prefix="dependency-private-")
         self._temp_decrypted_manifest_db_path = str(Path(self._temporary_folder) / "Manifest.db")
-        Path(self._temp_decrypted_manifest_db_path).write_bytes(b"private manifest")
-        self._temp_manifest_db_conn = _FakeConnection()
+        self._temp_manifest_db_conn = None
+
+    def _read_and_unlock_keybag(self) -> None:
+        self._manifest_plist = {"ManifestKey": struct.pack("<l", 1) + b"wrapped-key"}
 
     def test_decryption(self) -> None:
         return None
@@ -119,13 +115,10 @@ class _FakeBackup:
         file_plist: _FakeFilePlist,
         output_filepath: str,
     ) -> None:
-        if file_id != "a" * 40 or key != b"unwrapped-key":
-            raise AssertionError("Unexpected synthetic file metadata")
-        print(f"synthetic dependency warning for {output_filepath}")
-        Path(output_filepath).write_bytes(b"data")
+        raise AssertionError("the dependency path-only writer must not be called")
 
-    def save_manifest_file(self, output_path: str) -> None:
-        Path(output_path).write_bytes(b"synthetic decrypted manifest")
+    def save_manifest_file(self, _output_path: str) -> None:
+        raise AssertionError("the dependency path-only manifest writer must not be called")
 
     def _cleanup(self) -> None:
         print(f"synthetic dependency cleanup for {self._temp_decrypted_manifest_db_path}")
@@ -147,9 +140,41 @@ def _dependency_loader(
 
 
 def _write_selected_source_payload(backup: Path, file_id: str = "a" * 40) -> None:
+    from Crypto.Cipher import AES
+
     source = backup / file_id[:2] / file_id
     source.parent.mkdir(parents=True, exist_ok=True)
-    source.write_bytes(b"synthetic encrypted payload")
+    plaintext = b"data"
+    padding_size = 16 - len(plaintext) % 16
+    source.write_bytes(
+        AES.new(b"K" * 32, AES.MODE_CBC, iv=b"\x00" * 16).encrypt(
+            plaintext + bytes([padding_size]) * padding_size
+        )
+    )
+
+
+def _write_synthetic_encrypted_manifest(path: Path) -> None:
+    from Crypto.Cipher import AES
+
+    plaintext = path.with_name("synthetic-manifest.db")
+    connection = sqlite3.connect(plaintext)
+    try:
+        connection.execute(
+            "CREATE TABLE Files (fileID TEXT, domain TEXT, relativePath TEXT, "
+            "flags INTEGER, file BLOB)"
+        )
+        connection.execute(
+            "INSERT INTO Files VALUES (?, ?, ?, ?, ?)",
+            ("0" * 40, PRIMARY_DOMAIN, "Documents/synthetic.db", 1, b"synthetic"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    payload = plaintext.read_bytes()
+    plaintext.unlink()
+    if len(payload) % 16:
+        raise AssertionError("synthetic SQLite manifest was not block aligned")
+    path.write_bytes(AES.new(b"K" * 32, AES.MODE_CBC, iv=b"\x00" * 16).encrypt(payload))
 
 
 def _synthetic_preflight() -> PreflightResult:
@@ -166,6 +191,38 @@ def _synthetic_preflight() -> PreflightResult:
 
 
 class CliTests(unittest.TestCase):
+    @unittest.skipUnless(os.name == "nt", "Windows capability preflight regression")
+    def test_windows_capability_failure_stops_before_password(self) -> None:
+        from tvtime_extractor import windows_native
+
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            args = build_parser().parse_args(
+                [
+                    "recover",
+                    "--backup",
+                    str(base / "synthetic-backup"),
+                    "--output",
+                    str(base / "fresh-output"),
+                    "--acknowledge-sensitive-output",
+                ]
+            )
+            with (
+                mock.patch.object(
+                    windows_native,
+                    "require_recovery_capabilities",
+                    side_effect=windows_native.WindowsUnsupportedError(
+                        "synthetic unsupported filesystem"
+                    ),
+                ),
+                mock.patch("tvtime_extractor.cli.RecoveryService") as service,
+                mock.patch("tvtime_extractor.cli.read_backup_password") as read_password,
+                self.assertRaisesRegex(UserInputError, "unsupported filesystem"),
+            ):
+                _run_recovery(args)
+            service.assert_not_called()
+            read_password.assert_not_called()
+
     @unittest.skipIf(os.name == "nt", "CLI directory-descriptor binding is POSIX-only")
     def test_recover_holds_one_parent_descriptor_across_preflight_password_and_recovery(
         self,
@@ -542,7 +599,7 @@ class CliTests(unittest.TestCase):
             backup.mkdir()
             manifest = backup / "Manifest.plist"
             manifest.write_bytes(b"synthetic source manifest")
-            (backup / "Manifest.db").write_bytes(b"synthetic encrypted manifest database")
+            _write_synthetic_encrypted_manifest(backup / "Manifest.db")
             write_finished_status(backup)
             rows = [
                 (
@@ -614,7 +671,7 @@ class CliTests(unittest.TestCase):
             backup = base / "backup"
             backup.mkdir()
             (backup / "Manifest.plist").write_bytes(b"synthetic source manifest")
-            (backup / "Manifest.db").write_bytes(b"synthetic encrypted manifest database")
+            _write_synthetic_encrypted_manifest(backup / "Manifest.db")
             write_finished_status(backup)
             rows = [
                 (
@@ -641,16 +698,17 @@ class CliTests(unittest.TestCase):
             )
             self.assertEqual(result.summary["files_extracted"], 0)
             self.assertEqual(len(result.summary["failures"]), 1)
+            self.assertEqual(result.summary["failures"][0]["category"], "unsafe_path")
             self.assertFalse((base / "outside.txt").exists())
 
-    def test_dependency_copy_exception_text_is_not_persisted(self) -> None:
+    def test_dependency_path_writer_is_not_called_or_persisted(self) -> None:
         secret = "pass=do-not-leak /Users/private/Secret Show Title"
         with tempfile.TemporaryDirectory() as temporary:
             base = Path(temporary)
             backup = base / "backup"
             backup.mkdir()
             (backup / "Manifest.plist").write_bytes(b"synthetic source manifest")
-            (backup / "Manifest.db").write_bytes(b"synthetic encrypted manifest database")
+            _write_synthetic_encrypted_manifest(backup / "Manifest.db")
             write_finished_status(backup)
             rows = [
                 (
@@ -692,10 +750,7 @@ class CliTests(unittest.TestCase):
                 encoding="utf-8"
             )
             self.assertNotIn(secret, persisted)
-            self.assertEqual(
-                result.summary["failures"][0]["error"],
-                "The selected backup file could not be copied safely.",
-            )
+            self.assertEqual(result.summary["failures"], [])
 
     def test_size_discrepancy_is_publicly_visible_without_leaking_dependency_paths(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -703,7 +758,7 @@ class CliTests(unittest.TestCase):
             backup = base / "backup"
             backup.mkdir()
             (backup / "Manifest.plist").write_bytes(b"synthetic source manifest")
-            (backup / "Manifest.db").write_bytes(b"synthetic encrypted manifest database")
+            _write_synthetic_encrypted_manifest(backup / "Manifest.db")
             write_finished_status(backup)
             rows = [
                 (
@@ -732,8 +787,31 @@ class CliTests(unittest.TestCase):
                 )
 
             self.assertEqual(dependency_output.getvalue(), "")
-            self.assertEqual(len(result.summary["size_discrepancies"]), 1)
+            self.assertEqual(result.summary["files_extracted"], 1)
+            self.assertEqual(result.summary["failures"], [])
+            self.assertEqual(
+                result.summary["size_discrepancies"],
+                [
+                    {
+                        "domain": PRIMARY_DOMAIN,
+                        "relative_path": "Documents/example.bin",
+                        "declared_size": 5,
+                        "actual_size": 4,
+                    }
+                ],
+            )
             self.assertEqual(public_summary(result)["size_discrepancy_count"], 1)
+            self.assertEqual(
+                (
+                    result.extraction_root / "raw" / PRIMARY_DOMAIN / "Documents" / "example.bin"
+                ).read_bytes(),
+                b"data",
+            )
+            run_state = json.loads(
+                (result.extraction_root / "metadata" / "run_state.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(run_state["status"], "complete")
+            self.assertEqual(run_state["size_discrepancy_count"], 1)
 
     def test_dependency_failure_does_not_create_output(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
@@ -741,7 +819,7 @@ class CliTests(unittest.TestCase):
             backup = base / "backup"
             backup.mkdir()
             (backup / "Manifest.plist").write_bytes(b"synthetic source manifest")
-            (backup / "Manifest.db").write_bytes(b"synthetic encrypted manifest database")
+            _write_synthetic_encrypted_manifest(backup / "Manifest.db")
             write_finished_status(backup)
             output = base / "private-output"
 
@@ -766,7 +844,7 @@ class CliTests(unittest.TestCase):
             backup = base / "backup"
             backup.mkdir()
             (backup / "Manifest.plist").write_bytes(b"synthetic source manifest")
-            (backup / "Manifest.db").write_bytes(b"synthetic encrypted manifest database")
+            _write_synthetic_encrypted_manifest(backup / "Manifest.db")
             write_finished_status(backup)
             output = base / "private-output"
 

--- a/tests/test_cli_recovery_e2e.py
+++ b/tests/test_cli_recovery_e2e.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import contextlib
 import io
 import json
-import os
 import tempfile
 import unittest
 from pathlib import Path
@@ -24,9 +23,10 @@ from tvtime_extractor.extract import extract_backup as real_extract_backup
 from tvtime_extractor.visual_report import HTML_REPORT_FILENAME, PDF_REPORT_FILENAME
 
 
-@unittest.skipIf(os.name == "nt", "Full encrypted-backup recovery is POSIX-only")
 class CliSyntheticRecoveryEndToEndTests(unittest.TestCase):
     def test_recover_runs_full_synthetic_pipeline_and_validates_output(self) -> None:
+        from Crypto.Cipher import AES
+
         with tempfile.TemporaryDirectory(prefix="tvtime-cli-e2e-") as temporary:
             base = Path(temporary)
             template = create_synthetic_extraction(base / "template")
@@ -39,18 +39,25 @@ class CliSyntheticRecoveryEndToEndTests(unittest.TestCase):
             ):
                 file_id = f"{index:040x}"
                 payload = source.read_bytes()
+                relative_path = source.relative_to(template_app).as_posix()
+                declared_size = len(payload) + (relative_path == "Documents/DioCache.db")
                 plaintext[file_id] = payload
                 rows.append(
                     (
                         file_id,
                         PRIMARY_DOMAIN,
-                        source.relative_to(template_app).as_posix(),
-                        {"filesize": len(payload)},
+                        relative_path,
+                        {"filesize": declared_size},
                     )
                 )
                 encrypted = backup / file_id[:2] / file_id
                 encrypted.parent.mkdir(exist_ok=True)
-                encrypted.write_bytes(b"synthetic encrypted payload")
+                padding_size = 16 - len(payload) % 16
+                encrypted.write_bytes(
+                    AES.new(b"K" * 32, AES.MODE_CBC, iv=b"\x00" * 16).encrypt(
+                        payload + bytes([padding_size]) * padding_size
+                    )
+                )
 
             instances: list[_EndToEndBackup] = []
 
@@ -92,8 +99,9 @@ class CliSyntheticRecoveryEndToEndTests(unittest.TestCase):
                     ]
                 )
 
-            self.assertEqual(exit_code, 0)
+            self.assertEqual(exit_code, 0, stderr.getvalue())
             self.assertIn("TV Time extraction summary", stdout.getvalue())
+            self.assertIn("Size warnings: 1", stdout.getvalue())
             self.assertIn("TV Time analysis summary", stdout.getvalue())
             self.assertIn("Readable recovery report", stdout.getvalue())
             self.assertIn("Recovery completed successfully.", stderr.getvalue())
@@ -112,6 +120,7 @@ class CliSyntheticRecoveryEndToEndTests(unittest.TestCase):
             self.assertEqual(run_state["status"], "complete")
             self.assertEqual(run_state["files_expected"], len(rows))
             self.assertEqual(run_state["files_extracted"], len(rows))
+            self.assertEqual(run_state["size_discrepancy_count"], 1)
             self.assertEqual(recovery_state["status"], "complete")
             self.assertFalse((extraction / ".tmp").exists())
             self.assertFalse((extraction / ".analysis-incomplete").exists())
@@ -135,7 +144,7 @@ class CliSyntheticRecoveryEndToEndTests(unittest.TestCase):
                 ),
             )
             self.assertEqual(len(instances), 1)
-            self.assertTrue(instances[0].connection.closed)
+            self.assertIsNone(instances[0]._temp_manifest_db_conn)
             self.assertEqual(instances[0].cleanup_calls, 1)
 
 

--- a/tests/test_raw_integrity.py
+++ b/tests/test_raw_integrity.py
@@ -65,6 +65,7 @@ class RawChainIntegrityTests(unittest.TestCase):
                     analyze_extraction(extraction_directory=extraction)
                 self.assertFalse((extraction / "analysis").exists())
 
+    @unittest.skipIf(os.name == "nt", "Windows source handles deny concurrent mutation")
     def test_descriptor_bound_raw_hashing_rejects_an_in_place_race(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             extraction = create_synthetic_extraction(Path(temporary))

--- a/tests/test_recovery_output_validator.py
+++ b/tests/test_recovery_output_validator.py
@@ -331,6 +331,7 @@ class RecoveryOutputValidatorTests(unittest.TestCase):
         self.assertEqual(self._staging_members(output), [])
         self.assertEqual(_tree_snapshot(output), before)
 
+    @unittest.skipIf(os.name == "nt", "symbolic-link creation varies on Windows")
     def test_sqlite_snapshot_rejects_linked_sidecar_without_traversal(self) -> None:
         if not hasattr(os, "symlink"):
             self.skipTest("Symbolic links are unavailable")

--- a/tests/test_refract_conversion.py
+++ b/tests/test_refract_conversion.py
@@ -1,0 +1,366 @@
+from __future__ import annotations
+
+import contextlib
+import csv
+import hashlib
+import io
+import json
+import os
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+from unittest import mock
+
+from script import convert_refract_series as refract_cli
+from tvtime_extractor.errors import OutputExistsError
+from tvtime_extractor.refract import (
+    EPISODE_FIELDS,
+    FAVORITE_FIELDS,
+    SERIES_FIELDS,
+    RefractConversionError,
+    build_refract_series_payload,
+    convert_refract_series,
+)
+from tvtime_extractor.safety import (
+    secure_directory,
+    write_csv_private,
+    write_json_private,
+)
+
+
+def _series_row(**changes: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "uuid": "synthetic-series-uuid",
+        "series_id": "101",
+        "name": "Synthetic Series",
+        "country": "ZZ",
+        "is_ended": "False",
+        "followed_at": "2024-01-01T00:00:00Z",
+        "last_watch_date": "2024-02-03T04:05:06Z",
+        "filters": "followed | continuing",
+        "created_at": "2024-01-01T00:00:00Z",
+        "updated_at": "2024-02-03T04:05:06Z",
+    }
+    row.update(changes)
+    return row
+
+
+def _episode_row(**changes: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "source_id": "synthetic-cache-source",
+        "episode_id": "1001",
+        "show_id": "101",
+        "show_name": "Synthetic Series",
+        "season": "1",
+        "episode": "1",
+        "episode_name": "Synthetic Pilot",
+        "air_date": "2024-01-01T00:00:00Z",
+        "seen": "True",
+        "seen_date": "2024-02-03T05:05:06+01:00",
+        "is_watched": "False",
+        "runtime": "2700",
+    }
+    row.update(changes)
+    return row
+
+
+def _favorite_row(**changes: object) -> dict[str, object]:
+    row: dict[str, object] = {
+        "uuid": "synthetic-favorite-uuid",
+        "id": "101",
+        "name": "Synthetic Series",
+        "type": "series",
+        "status": "followed",
+        "created_at": "2024-01-01T00:00:00Z",
+        "watched_episode_count": "1",
+        "aired_episode_count": "1",
+        "is_followed": "True",
+        "is_up_to_date": "True",
+    }
+    row.update(changes)
+    return row
+
+
+def _write_analysis(
+    root: Path,
+    *,
+    series: list[dict[str, object]],
+    episodes: list[dict[str, object]] | None = None,
+    favorites: list[dict[str, object]] | None = None,
+) -> Path:
+    extraction = secure_directory(root / "Synthetic-Extraction")
+    analysis = secure_directory(extraction / "analysis")
+    escapes: dict[str, object] = {}
+    series_escapes = write_csv_private(
+        analysis / "series_library.csv",
+        series,
+        SERIES_FIELDS,
+    )
+    if series_escapes:
+        escapes["series_library.csv"] = series_escapes
+    if episodes is not None:
+        episode_escapes = write_csv_private(
+            analysis / "episode_cache_unique.csv",
+            episodes,
+            EPISODE_FIELDS,
+        )
+        if episode_escapes:
+            escapes["episode_cache_unique.csv"] = episode_escapes
+    if favorites is not None:
+        favorite_escapes = write_csv_private(
+            analysis / "favorite_shows.csv",
+            favorites,
+            FAVORITE_FIELDS,
+        )
+        if favorite_escapes:
+            escapes["favorite_shows.csv"] = favorite_escapes
+    write_json_private(
+        analysis / "analysis_summary.json",
+        {"csv_spreadsheet_escaped_cells": escapes},
+    )
+    return analysis
+
+
+def _analysis_hashes(analysis: Path) -> dict[str, str]:
+    return {
+        path.name: hashlib.sha256(path.read_bytes()).hexdigest()
+        for path in sorted(analysis.iterdir())
+    }
+
+
+class RefractPayloadTests(unittest.TestCase):
+    def test_maps_series_episodes_specials_favorites_and_recorded_escapes(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            analysis = _write_analysis(
+                root,
+                series=[
+                    _series_row(name="=Synthetic Escaped Series"),
+                    _series_row(
+                        uuid="synthetic-empty-uuid",
+                        series_id="202",
+                        name="Synthetic Empty Series",
+                        created_at="",
+                    ),
+                ],
+                episodes=[
+                    _episode_row(),
+                    _episode_row(
+                        episode_id="1002",
+                        season="0",
+                        episode="2",
+                        episode_name="Synthetic Special",
+                        seen="False",
+                        seen_date="",
+                        is_watched="False",
+                    ),
+                    _episode_row(
+                        episode_id="1003",
+                        episode="3",
+                        episode_name="TBA",
+                    ),
+                    _episode_row(episode_id="9001", show_id="999"),
+                ],
+                favorites=[
+                    _favorite_row(),
+                    _favorite_row(uuid="synthetic-unmatched-favorite", id="999"),
+                ],
+            )
+
+            payload, stats = build_refract_series_payload(analysis)
+
+            self.assertEqual(stats.series, 2)
+            self.assertEqual(stats.episodes, 2)
+            self.assertEqual(stats.unmatched_episode_rows, 1)
+            self.assertEqual(stats.ignored_episode_rows, 1)
+            self.assertEqual(stats.unmatched_favorite_rows, 1)
+            first = payload[0]
+            self.assertEqual(first["title"], "=Synthetic Escaped Series")
+            self.assertEqual(first["id"], {"tvdb": 101, "imdb": None})
+            self.assertEqual(first["status"], "up_to_date")
+            self.assertTrue(first["is_favorite"])
+            self.assertFalse(first["_noEpisodeData"])
+            self.assertEqual([season["number"] for season in first["seasons"]], [0, 1])
+            special = first["seasons"][0]["episodes"][0]
+            watched = first["seasons"][1]["episodes"][0]
+            self.assertTrue(special["special"])
+            self.assertFalse(special["is_watched"])
+            self.assertEqual(special["watched_count"], 0)
+            self.assertEqual(watched["watched_at"], "2024-02-03T04:05:06Z")
+            self.assertTrue(watched["is_watched"])
+            self.assertEqual(watched["rewatch_count"], 0)
+            self.assertEqual(watched["watched_count"], 1)
+
+            empty = payload[1]
+            self.assertEqual(empty["title"], "Synthetic Empty Series")
+            self.assertEqual(empty["status"], "up_to_date")
+            self.assertIsNone(empty["created_at"])
+            self.assertTrue(empty["_noEpisodeData"])
+            self.assertEqual(empty["seasons"], [])
+
+    def test_missing_optional_tables_produces_completed_status_with_empty_seasons(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            analysis = _write_analysis(Path(temporary), series=[_series_row()])
+
+            payload, stats = build_refract_series_payload(analysis)
+
+            self.assertEqual(stats.episodes, 0)
+            self.assertEqual(payload[0]["status"], "up_to_date")
+            self.assertTrue(payload[0]["_noEpisodeData"])
+            self.assertEqual(payload[0]["seasons"], [])
+            self.assertFalse(payload[0]["is_favorite"])
+
+    def test_seen_flag_survives_an_invalid_watch_date_without_inference(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            analysis = _write_analysis(
+                Path(temporary),
+                series=[_series_row(last_watch_date="2099-12-31T23:59:59Z")],
+                episodes=[_episode_row(seen="True", seen_date="not-a-date")],
+            )
+
+            payload, _stats = build_refract_series_payload(analysis)
+
+            episode = payload[0]["seasons"][0]["episodes"][0]
+            self.assertTrue(episode["is_watched"])
+            self.assertIsNone(episode["watched_at"])
+
+    def test_invalid_or_duplicate_series_ids_fail(self) -> None:
+        for rows in (
+            [_series_row(series_id="not-an-id")],
+            [_series_row(), _series_row(uuid="synthetic-duplicate")],
+        ):
+            with self.subTest(rows=len(rows)), tempfile.TemporaryDirectory() as temporary:
+                analysis = _write_analysis(Path(temporary), series=rows)
+                with self.assertRaises(RefractConversionError):
+                    build_refract_series_payload(analysis)
+
+    def test_malformed_header_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            extraction = secure_directory(root / "Synthetic-Extraction")
+            analysis = secure_directory(extraction / "analysis")
+            with (analysis / "series_library.csv").open(
+                "w", encoding="utf-8", newline=""
+            ) as handle:
+                writer = csv.DictWriter(
+                    handle,
+                    fieldnames=SERIES_FIELDS[:-1],
+                    extrasaction="ignore",
+                )
+                writer.writeheader()
+                writer.writerow(_series_row())
+            if os.name != "nt":
+                os.chmod(analysis / "series_library.csv", 0o600)
+            write_json_private(
+                analysis / "analysis_summary.json",
+                {"csv_spreadsheet_escaped_cells": {}},
+            )
+
+            with self.assertRaises(RefractConversionError):
+                build_refract_series_payload(analysis)
+
+
+class RefractOutputTests(unittest.TestCase):
+    def test_conversion_creates_only_atomic_json_and_does_not_change_inputs(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            analysis = _write_analysis(
+                root,
+                series=[_series_row()],
+                episodes=[_episode_row()],
+                favorites=[_favorite_row()],
+            )
+            before = _analysis_hashes(analysis)
+            output = root / "Synthetic-Refract-Output"
+
+            result = convert_refract_series(
+                analysis_directory=analysis,
+                output_directory=output,
+                export_date=date(2026, 7, 23),
+            )
+
+            self.assertEqual(before, _analysis_hashes(analysis))
+            self.assertEqual(result.output_file.name, "tvtime-series-2026-07-23.json")
+            self.assertEqual([path.name for path in output.iterdir()], [result.output_file.name])
+            payload = json.loads(result.output_file.read_text(encoding="utf-8"))
+            self.assertIsInstance(payload, list)
+            self.assertEqual(payload[0]["id"]["tvdb"], 101)
+            if os.name != "nt":
+                self.assertEqual(stat_mode(output), 0o700)
+                self.assertEqual(stat_mode(result.output_file), 0o600)
+
+    def test_existing_output_is_never_overwritten(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            analysis = _write_analysis(root, series=[_series_row()])
+            output = secure_directory(root / "Synthetic-Existing-Output")
+            sentinel = output / "synthetic-sentinel.txt"
+            sentinel.write_text("synthetic sentinel", encoding="utf-8")
+
+            with self.assertRaises(OutputExistsError):
+                convert_refract_series(
+                    analysis_directory=analysis,
+                    output_directory=output,
+                    export_date=date(2026, 7, 23),
+                )
+
+            self.assertEqual(sentinel.read_text(encoding="utf-8"), "synthetic sentinel")
+
+    def test_invalid_input_creates_no_output_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            analysis = _write_analysis(root, series=[_series_row(series_id="invalid")])
+            output = root / "Synthetic-No-Output"
+
+            with self.assertRaises(RefractConversionError):
+                convert_refract_series(
+                    analysis_directory=analysis,
+                    output_directory=output,
+                    export_date=date(2026, 7, 23),
+                )
+
+            self.assertFalse(output.exists())
+
+    def test_cli_suppresses_unexpected_secret_bearing_exception_text(self) -> None:
+        secret = "SYNTHETIC-PASSWORD C:\\Synthetic\\Private recovered title"
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(
+                refract_cli,
+                "convert_refract_series",
+                side_effect=RuntimeError(secret),
+            ),
+            contextlib.redirect_stdout(stdout),
+            contextlib.redirect_stderr(stderr),
+        ):
+            result = refract_cli.main(
+                ["--analysis", "Synthetic-Analysis", "--output", "Synthetic-Output"]
+            )
+
+        self.assertEqual(result, 1)
+        self.assertNotIn(secret, stdout.getvalue())
+        self.assertNotIn(secret, stderr.getvalue())
+        self.assertNotIn("RuntimeError", stderr.getvalue())
+
+    @unittest.skipUnless(os.name == "nt", "Windows path parsing applies only on Windows")
+    def test_cli_accepts_windows_paths(self) -> None:
+        arguments = refract_cli.build_parser().parse_args(
+            [
+                "--analysis",
+                r"C:\Private\Synthetic-Extraction\analysis",
+                "--output",
+                r"C:\Private\Synthetic-Refract-Output",
+            ]
+        )
+        self.assertTrue(arguments.analysis.is_absolute())
+        self.assertTrue(arguments.output.is_absolute())
+
+
+def stat_mode(path: Path) -> int:
+    return path.stat().st_mode & 0o777
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_safety.py
+++ b/tests/test_safety.py
@@ -1274,21 +1274,43 @@ class WindowsDirectoryHandleContractTests(unittest.TestCase):
                 raise RuntimeError("synthetic body failure")
             self.assertEqual(closed, [101])
 
-    def test_windows_fresh_output_fails_before_create_or_handle_open(self) -> None:
+    def test_windows_fresh_output_is_atomically_created_and_held(self) -> None:
+        output = no_link_absolute_path(Path("C:/Synthetic/Private/fresh-output"))
+        identity = (7, 11)
+        closed: list[int] = []
         with (
             mock.patch("tvtime_extractor.safety._running_on_windows", return_value=True),
             mock.patch("tvtime_extractor.safety.os.mkdir") as mkdir,
-            mock.patch("tvtime_extractor.safety._windows_open_locked_directory") as open_root,
-            self.assertRaisesRegex(UserInputError, "not supported on Windows"),
+            mock.patch("tvtime_extractor.safety.require_fresh_output_platform_support"),
+            mock.patch(
+                "tvtime_extractor.safety.require_bound_destination_parent",
+                return_value=output.parent,
+            ),
+            mock.patch("tvtime_extractor.safety._windows_native.require_private_ntfs_volume"),
+            mock.patch(
+                "tvtime_extractor.safety._windows_native.create_fresh_directory",
+                return_value=101,
+            ) as create,
+            mock.patch(
+                "tvtime_extractor.safety._windows_directory_identity",
+                return_value=identity,
+            ),
+            mock.patch("tvtime_extractor.safety._require_windows_visible_directory_identity"),
+            mock.patch("tvtime_extractor.safety._require_visible_output_identity"),
+            mock.patch(
+                "tvtime_extractor.safety._windows_close_handle",
+                side_effect=closed.append,
+            ),
             anchored_bound_output_root(
-                Path("/synthetic/private/fresh-output"),
+                output,
                 destination_parent_descriptor=99,
                 expected_parent_identity=(5, 6),
-            ),
+            ) as bound,
         ):
-            pass
+            self.assertEqual(bound, output)
         mkdir.assert_not_called()
-        open_root.assert_not_called()
+        create.assert_called_once_with(99, "fresh-output")
+        self.assertEqual(closed, [101])
 
     def test_windows_existing_root_is_held_validated_and_closed_on_body_failure(self) -> None:
         identity = (7, 11)

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -1,21 +1,26 @@
 from __future__ import annotations
 
 import contextlib
+import errno
 import hashlib
 import io
 import json
 import os
 import plistlib
 import shutil
+import sqlite3
+import struct
 import sys
 import tempfile
 import unittest
+from dataclasses import replace
 from pathlib import Path
 from typing import Any
 from unittest import mock
 
 from tvtime_extractor.errors import (
     BackupUnfinishedError,
+    InsufficientSpaceError,
     SourceChangedError,
     TVTimeError,
     UnsafePathError,
@@ -23,13 +28,20 @@ from tvtime_extractor.errors import (
 from tvtime_extractor.extract import (
     PRIMARY_DOMAIN,
     _bounded_manifest_rows,
+    _close_repository_manifest,
     _create_private_staging_descriptor,
+    _decrypt_cbc_to_descriptor,
+    _DescriptorDecryptionFailure,
     _finished_status_state,
     _harden_private_staging_descriptor,
+    _prepare_repository_owned_manifest,
+    _SelectedFileCopyFailure,
+    _SelectedFileFailureCategory,
     _sha256_staging_descriptor,
     _source_payload_state,
     _verified_dependency_output_alias,
     extract_backup,
+    public_summary_json,
 )
 from tvtime_extractor.report import read_csv
 from tvtime_extractor.safety import (
@@ -41,11 +53,13 @@ from tvtime_extractor.safety import (
 
 
 class _Connection:
-    def __init__(self, *, fail: bool = False) -> None:
+    def __init__(self, delegate: sqlite3.Connection, *, fail: bool = False) -> None:
+        self.delegate = delegate
         self.fail = fail
         self.closed = False
 
     def close(self) -> None:
+        self.delegate.close()
         self.closed = True
         if self.fail:
             raise OSError("synthetic close failure")
@@ -53,7 +67,7 @@ class _Connection:
 
 class _Keybag:
     def unwrapKeyForClass(self, _protection_class: object, _wrapped_key: object) -> bytes:
-        return b"synthetic-unwrapped-key"
+        return b"K" * 32
 
 
 class _FilePlist:
@@ -123,15 +137,21 @@ class _CleanupBackup:
         self._manifest_plist = {"private": True}
         self._temporary_folder = tempfile.mkdtemp(prefix="dependency-private-")
         self._temp_decrypted_manifest_db_path = str(Path(self._temporary_folder) / "Manifest.db")
-        Path(self._temp_decrypted_manifest_db_path).write_bytes(b"private manifest")
-        self.connection = _Connection(fail=close_fails)
-        self._temp_manifest_db_conn = self.connection
+        self.connection: _Connection | None = None
+        self._temp_manifest_db_conn = None
         self.cleanup_calls = 0
         self.run_state_at_cleanup = ""
-        self.decrypted_from_private_snapshot = False
+        self.path_writer_called = False
+
+    def _read_and_unlock_keybag(self) -> None:
+        self._manifest_plist = {"ManifestKey": struct.pack("<l", 1) + b"wrapped"}
 
     def test_decryption(self) -> None:
         print("dependency test private path", file=os.sys.stderr)
+        if self._temp_manifest_db_conn is None:
+            raise AssertionError("repository-owned manifest connection was unavailable")
+        self.connection = _Connection(self._temp_manifest_db_conn, fail=self.close_fails)
+        self._temp_manifest_db_conn = self.connection
         if self.decryption_fails:
             raise RuntimeError("original synthetic decryption failure")
 
@@ -146,21 +166,12 @@ class _CleanupBackup:
         file_plist: _FilePlist,
         output_filepath: str,
     ) -> None:
-        self.assert_key(key)
-        source = Path(self._backup_directory) / file_id[:2] / file_id
-        self.decrypted_from_private_snapshot = (
-            source.is_file()
-            and source.parent.parent != self.backup_directory
-            and source.read_bytes() == b"synthetic encrypted payload"
-        )
-        if not self.decrypted_from_private_snapshot:
-            raise AssertionError("decryption did not use the verified private source snapshot")
-        print(f"dependency output path: {output_filepath}")
-        Path(output_filepath).write_bytes(self.plaintext[file_id])
+        self.path_writer_called = True
+        raise AssertionError("the dependency path-only writer must not be called")
 
     @staticmethod
     def assert_key(key: bytes) -> None:
-        if key != b"synthetic-unwrapped-key":
+        if key != b"K" * 32:
             raise AssertionError("unexpected synthetic key")
 
     def _cleanup(self) -> None:
@@ -218,6 +229,206 @@ class ManifestBoundsTests(unittest.TestCase):
                         validate_row=lambda _row: None,
                     )
                 self.assertTrue(cursor.fetch_sizes)
+
+
+class DescriptorDecryptionTests(unittest.TestCase):
+    @staticmethod
+    def _encrypt(plaintext: bytes, *, key: bytes) -> bytes:
+        from Crypto.Cipher import AES
+
+        padding_size = 16 - len(plaintext) % 16
+        padded = plaintext + bytes([padding_size]) * padding_size
+        return AES.new(key, AES.MODE_CBC, iv=b"\x00" * 16).encrypt(padded)
+
+    def test_chunked_cbc_decryption_matches_known_boundaries(self) -> None:
+        key = bytes(range(32))
+        for size in (0, 1, 15, 16, 17, 1024 * 1024 - 1, 1024 * 1024, 1024 * 1024 + 1):
+            with self.subTest(size=size), tempfile.TemporaryDirectory() as temporary:
+                root = Path(temporary)
+                plaintext = bytes(index % 251 for index in range(size))
+                encrypted = root / "encrypted.bin"
+                encrypted.write_bytes(self._encrypt(plaintext, key=key))
+                encrypted.chmod(0o600)
+                output = root / "decrypted.partial"
+                descriptor = os.open(
+                    output,
+                    os.O_CREAT | os.O_EXCL | os.O_RDWR | getattr(os, "O_BINARY", 0),
+                    0o600,
+                )
+                try:
+                    _decrypt_cbc_to_descriptor(
+                        encrypted,
+                        descriptor,
+                        key=key,
+                        declared_size=size,
+                    )
+                    os.lseek(descriptor, 0, os.SEEK_SET)
+                    actual = bytearray()
+                    while True:
+                        chunk = os.read(descriptor, 1024 * 1024)
+                        if not chunk:
+                            break
+                        actual.extend(chunk)
+                    self.assertEqual(len(actual), size)
+                    self.assertEqual(bytes(actual), plaintext)
+                finally:
+                    os.close(descriptor)
+
+    def test_repository_manifest_session_is_immutable_and_descriptor_locked(self) -> None:
+        from Crypto.Cipher import AES
+
+        key = b"M" * 32
+
+        class Keybag:
+            def unwrapKeyForClass(self, protection_class: object, wrapped: object) -> bytes:
+                if protection_class != 7 or wrapped != b"wrapped-manifest-key":
+                    raise AssertionError("unexpected synthetic manifest metadata")
+                return key
+
+        class Backup:
+            def __init__(self, manifest_path: Path) -> None:
+                self._manifest_plist: dict[str, object] | None = None
+                self._keybag: Keybag | None = None
+                self._temp_decrypted_manifest_db_path = str(manifest_path)
+                self._temp_manifest_db_conn = None
+
+            def _read_and_unlock_keybag(self) -> None:
+                self._manifest_plist = {
+                    "ManifestKey": struct.pack("<l", 7) + b"wrapped-manifest-key"
+                }
+                self._keybag = Keybag()
+
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            plaintext = root / "plaintext.db"
+            connection = sqlite3.connect(plaintext)
+            connection.execute(
+                "CREATE TABLE Files (fileID TEXT, domain TEXT, relativePath TEXT, "
+                "flags INTEGER, file BLOB)"
+            )
+            connection.execute(
+                "INSERT INTO Files VALUES (?, ?, ?, ?, ?)",
+                ("0" * 40, PRIMARY_DOMAIN, "Documents/synthetic.db", 1, b"synthetic"),
+            )
+            connection.commit()
+            connection.close()
+            plaintext_bytes = plaintext.read_bytes()
+            self.assertEqual(len(plaintext_bytes) % 16, 0)
+            encrypted = root / "Manifest.encrypted.db"
+            encrypted.write_bytes(
+                AES.new(key, AES.MODE_CBC, iv=b"\x00" * 16).encrypt(plaintext_bytes)
+            )
+            encrypted.chmod(0o600)
+            temp_root = root / "private-temp"
+            temp_root.mkdir(mode=0o700)
+            manifest_path = temp_root / "Manifest.db"
+            backup = Backup(manifest_path)
+
+            _prepare_repository_owned_manifest(
+                backup,
+                encrypted_manifest=encrypted,
+                temp_root=temp_root,
+            )
+            assert backup._temp_manifest_db_conn is not None
+            self.assertEqual(
+                backup._temp_manifest_db_conn.execute("SELECT count(*) FROM Files").fetchone(),
+                (1,),
+            )
+            with self.assertRaises(sqlite3.OperationalError):
+                backup._temp_manifest_db_conn.execute("DELETE FROM Files")
+            if os.name == "nt":
+                with self.assertRaises(OSError):
+                    manifest_path.write_bytes(b"changed")
+            _close_repository_manifest(backup)
+
+    def test_chunked_cbc_decryption_records_fixed_validation_categories(self) -> None:
+        from Crypto.Cipher import AES
+
+        key = b"K" * 32
+        cases = (
+            (
+                AES.new(key, AES.MODE_CBC, iv=b"\x00" * 16).encrypt(b"X" * 15 + b"\x00"),
+                key,
+                15,
+                _SelectedFileFailureCategory.PADDING_FAILURE,
+            ),
+            (
+                self._encrypt(b"synthetic", key=key),
+                key,
+                len(b"synthetic") + 1,
+                _SelectedFileFailureCategory.SIZE_MISMATCH,
+            ),
+            (
+                b"not-block-aligned",
+                key,
+                1,
+                _SelectedFileFailureCategory.CIPHERTEXT_INVALID,
+            ),
+            (
+                self._encrypt(b"synthetic", key=key),
+                b"invalid",
+                len(b"synthetic"),
+                _SelectedFileFailureCategory.KEY_UNWRAP_FAILURE,
+            ),
+        )
+        for encrypted_payload, selected_key, declared_size, expected_category in cases:
+            with (
+                self.subTest(category=expected_category.value),
+                tempfile.TemporaryDirectory() as temporary,
+            ):
+                root = Path(temporary)
+                encrypted = root / "encrypted.bin"
+                encrypted.write_bytes(encrypted_payload)
+                encrypted.chmod(0o600)
+                output = root / "decrypted.partial"
+                descriptor = os.open(
+                    output,
+                    os.O_CREAT | os.O_EXCL | os.O_RDWR | getattr(os, "O_BINARY", 0),
+                    0o600,
+                )
+                try:
+                    with self.assertRaises(_DescriptorDecryptionFailure) as raised:
+                        _decrypt_cbc_to_descriptor(
+                            encrypted,
+                            descriptor,
+                            key=selected_key,
+                            declared_size=declared_size,
+                        )
+                    self.assertEqual(raised.exception.category, expected_category)
+                    self.assertEqual(
+                        str(raised.exception),
+                        "The selected backup file could not be copied safely.",
+                    )
+                finally:
+                    os.close(descriptor)
+
+    def test_chunked_cbc_decryption_can_return_a_valid_size_warning(self) -> None:
+        key = b"K" * 32
+        plaintext = b"synthetic"
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            encrypted = root / "encrypted.bin"
+            encrypted.write_bytes(self._encrypt(plaintext, key=key))
+            encrypted.chmod(0o600)
+            output = root / "decrypted.partial"
+            descriptor = os.open(
+                output,
+                os.O_CREAT | os.O_EXCL | os.O_RDWR | getattr(os, "O_BINARY", 0),
+                0o600,
+            )
+            try:
+                written = _decrypt_cbc_to_descriptor(
+                    encrypted,
+                    descriptor,
+                    key=key,
+                    declared_size=len(plaintext) + 1,
+                    allow_size_mismatch=True,
+                )
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                self.assertEqual(written, len(plaintext))
+                self.assertEqual(os.read(descriptor, len(plaintext)), plaintext)
+            finally:
+                os.close(descriptor)
 
 
 @unittest.skipUnless(
@@ -321,10 +532,32 @@ class DependencyDescriptorBindingTests(unittest.TestCase):
 
 
 def _write_backup(base: Path, *, snapshot_state: str = "finished") -> Path:
+    from Crypto.Cipher import AES
+
     backup = base / "backup"
     backup.mkdir()
     (backup / "Manifest.plist").write_bytes(b"synthetic manifest")
-    (backup / "Manifest.db").write_bytes(b"synthetic encrypted manifest")
+    plaintext_manifest = base / "synthetic-manifest.db"
+    connection = sqlite3.connect(plaintext_manifest)
+    try:
+        connection.execute(
+            "CREATE TABLE Files (fileID TEXT, domain TEXT, relativePath TEXT, "
+            "flags INTEGER, file BLOB)"
+        )
+        connection.execute(
+            "INSERT INTO Files VALUES (?, ?, ?, ?, ?)",
+            ("0" * 40, PRIMARY_DOMAIN, "Documents/synthetic.db", 1, b"synthetic"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    manifest_bytes = plaintext_manifest.read_bytes()
+    plaintext_manifest.unlink()
+    if len(manifest_bytes) % 16:
+        raise AssertionError("synthetic SQLite manifest was not block aligned")
+    (backup / "Manifest.db").write_bytes(
+        AES.new(b"K" * 32, AES.MODE_CBC, iv=b"\x00" * 16).encrypt(manifest_bytes)
+    )
     with (backup / "Status.plist").open("wb") as handle:
         plistlib.dump({"SnapshotState": snapshot_state}, handle)
     return backup
@@ -333,10 +566,17 @@ def _write_backup(base: Path, *, snapshot_state: str = "finished") -> Path:
 def _row(
     backup: Path, *, plaintext: bytes = b"recovered"
 ) -> tuple[list[tuple[Any, ...]], dict[str, bytes]]:
+    from Crypto.Cipher import AES
+
     file_id = "a" * 40
     encrypted = backup / file_id[:2] / file_id
     encrypted.parent.mkdir()
-    encrypted.write_bytes(b"synthetic encrypted payload")
+    padding_size = 16 - len(plaintext) % 16
+    encrypted.write_bytes(
+        AES.new(b"K" * 32, AES.MODE_CBC, iv=b"\x00" * 16).encrypt(
+            plaintext + bytes([padding_size]) * padding_size
+        )
+    )
     return (
         [
             (
@@ -355,6 +595,7 @@ def _loader(
     *,
     rows: list[tuple[Any, ...]],
     plaintext: dict[str, bytes],
+    file_plist_factory: type[_FilePlist] | Any = _FilePlist,
     close_fails: bool = False,
     cleanup_fails: bool = False,
     decryption_fails: bool = False,
@@ -375,7 +616,7 @@ def _loader(
             instances.append(instance)
             return instance
 
-        return factory, _FilePlist
+        return factory, file_plist_factory
 
     return load
 
@@ -446,6 +687,321 @@ class AtomicAndInputSafetyTests(unittest.TestCase):
 
 
 class ExtractionLifecycleSecurityTests(unittest.TestCase):
+    @staticmethod
+    def _single_failure_category(result: Any) -> str:
+        summary = result.summary
+        failures = summary["failures"]
+        if not isinstance(failures, list) or len(failures) != 1:
+            raise AssertionError("expected one synthetic selected-file failure")
+        return str(failures[0]["category"])
+
+    def test_private_failure_inventory_serializes_every_fixed_category(self) -> None:
+        for category in _SelectedFileFailureCategory:
+            with self.subTest(category=category.value), tempfile.TemporaryDirectory() as temporary:
+                base = Path(temporary)
+                backup = _write_backup(base)
+                rows, plaintext = _row(backup)
+                with mock.patch(
+                    "tvtime_extractor.extract._extract_one_file",
+                    side_effect=_SelectedFileCopyFailure(category),
+                ):
+                    result = extract_backup(
+                        backup_directory=backup,
+                        output_directory=base / "output",
+                        passphrase="synthetic password",
+                        dependency_loader=_loader([], rows=rows, plaintext=plaintext),
+                    )
+
+                failure = result.summary["failures"][0]
+                self.assertEqual(
+                    set(failure),
+                    {"file_id", "domain", "relative_path", "error", "category"},
+                )
+                self.assertEqual(failure["category"], category.value)
+                self.assertEqual(
+                    failure["error"],
+                    "The selected backup file could not be copied safely.",
+                )
+                self.assertNotIn(category.value, public_summary_json(result))
+                marker = read_json_regular(result.extraction_root / "metadata" / "run_state.json")
+                self.assertEqual(marker["status"], "incomplete")
+                self.assertEqual(
+                    [
+                        path
+                        for path in (result.extraction_root / "raw").rglob("*")
+                        if path.is_file()
+                    ],
+                    [],
+                )
+
+    def test_missing_key_and_invalid_metadata_are_classified(self) -> None:
+        class MissingKeyPlist(_FilePlist):
+            def __init__(self, value: dict[str, Any]) -> None:
+                super().__init__(value)
+                self.encryption_key = None
+
+        cases: list[tuple[str, Any]] = [
+            ("missing_encryption_key", MissingKeyPlist),
+        ]
+
+        calls = 0
+
+        def changing_plist(value: dict[str, Any]) -> _FilePlist:
+            nonlocal calls
+            calls += 1
+            parsed = _FilePlist(value)
+            if calls > 1:
+                parsed.filesize = "synthetic-invalid-size"
+            return parsed
+
+        cases.append(("invalid_manifest_metadata", changing_plist))
+        for expected, factory in cases:
+            with self.subTest(category=expected), tempfile.TemporaryDirectory() as temporary:
+                calls = 0
+                base = Path(temporary)
+                backup = _write_backup(base)
+                rows, plaintext = _row(backup)
+                result = extract_backup(
+                    backup_directory=backup,
+                    output_directory=base / "output",
+                    passphrase="synthetic password",
+                    dependency_loader=_loader(
+                        [],
+                        rows=rows,
+                        plaintext=plaintext,
+                        file_plist_factory=factory,
+                    ),
+                )
+                self.assertEqual(self._single_failure_category(result), expected)
+
+    def test_key_unwrap_failure_discards_dependency_output_and_exception_details(self) -> None:
+        secret = "synthetic-secret password title path"
+        calls = 0
+
+        def unwrap(_keybag: object, _protection_class: object, _wrapped: object) -> bytes:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return b"K" * 32
+            print(secret)
+            print(secret, file=sys.stderr)
+            raise RuntimeError(secret)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            backup = _write_backup(base)
+            rows, plaintext = _row(backup)
+            captured = io.StringIO()
+            with (
+                mock.patch.object(_Keybag, "unwrapKeyForClass", new=unwrap),
+                contextlib.redirect_stdout(captured),
+                contextlib.redirect_stderr(captured),
+            ):
+                result = extract_backup(
+                    backup_directory=backup,
+                    output_directory=base / "output",
+                    passphrase="synthetic password",
+                    dependency_loader=_loader([], rows=rows, plaintext=plaintext),
+                )
+            private_summary = (result.extraction_root / "metadata" / "summary.json").read_text(
+                encoding="utf-8"
+            )
+            self.assertEqual(self._single_failure_category(result), "key_unwrap_failure")
+            self.assertNotIn(secret, private_summary)
+            self.assertNotIn(secret, public_summary_json(result))
+            self.assertNotIn(secret, captured.getvalue())
+
+    def test_source_snapshot_failures_are_classified_without_promoting_plaintext(self) -> None:
+        real_source_state = _source_payload_state
+        for expected in ("source_unavailable", "source_changed"):
+            with self.subTest(category=expected), tempfile.TemporaryDirectory() as temporary:
+                base = Path(temporary)
+                backup = _write_backup(base)
+                rows, plaintext = _row(backup)
+
+                def source_state(
+                    path: Path,
+                    expected_category: str = expected,
+                    **kwargs: Any,
+                ) -> object:
+                    result = real_source_state(path, **kwargs)
+                    destination = kwargs.get("snapshot_destination")
+                    if destination is not None and "encrypted-source" in Path(destination).parts:
+                        if expected_category == "source_unavailable":
+                            raise OSError(errno.EIO, "synthetic private source detail")
+                        return replace(result, sha256="0" * 64)
+                    return result
+
+                with mock.patch(
+                    "tvtime_extractor.extract._source_payload_state",
+                    side_effect=source_state,
+                ):
+                    result = extract_backup(
+                        backup_directory=backup,
+                        output_directory=base / "output",
+                        passphrase="synthetic password",
+                        dependency_loader=_loader([], rows=rows, plaintext=plaintext),
+                    )
+                self.assertEqual(self._single_failure_category(result), expected)
+                self.assertEqual(
+                    [
+                        path
+                        for path in (result.extraction_root / "raw").rglob("*")
+                        if path.is_file()
+                    ],
+                    [],
+                )
+
+    def test_staging_promotion_and_unrecognized_failures_are_classified(self) -> None:
+        real_create = _create_private_staging_descriptor
+        real_decrypt = _decrypt_cbc_to_descriptor
+
+        def fail_staging(path: Path) -> tuple[int, tuple[int, int]]:
+            if path.name.endswith(".partial"):
+                raise OSError(errno.EIO, "synthetic private staging detail")
+            return real_create(path)
+
+        def fail_selected_decryption(*args: Any, **kwargs: Any) -> None:
+            if kwargs.get("strip_padding") is False:
+                real_decrypt(*args, **kwargs)
+                return
+            raise RuntimeError("synthetic private unknown detail")
+
+        cases = (
+            (
+                "staging_failure",
+                mock.patch(
+                    "tvtime_extractor.extract._create_private_staging_descriptor",
+                    side_effect=fail_staging,
+                ),
+            ),
+            (
+                "promotion_failure",
+                mock.patch(
+                    "tvtime_extractor.extract.promote_open_file_no_replace_atomic",
+                    side_effect=OSError(errno.EIO, "synthetic private promotion detail"),
+                ),
+            ),
+            (
+                "unrecognized_failure",
+                mock.patch(
+                    "tvtime_extractor.extract._decrypt_cbc_to_descriptor",
+                    side_effect=fail_selected_decryption,
+                ),
+            ),
+        )
+        for expected, patcher in cases:
+            with (
+                self.subTest(category=expected),
+                tempfile.TemporaryDirectory() as temporary,
+                patcher,
+            ):
+                base = Path(temporary)
+                backup = _write_backup(base)
+                rows, plaintext = _row(backup)
+                result = extract_backup(
+                    backup_directory=backup,
+                    output_directory=base / "output",
+                    passphrase="synthetic password",
+                    dependency_loader=_loader([], rows=rows, plaintext=plaintext),
+                )
+                self.assertEqual(self._single_failure_category(result), expected)
+
+    def test_disk_exhaustion_remains_a_global_failure(self) -> None:
+        real_create = _create_private_staging_descriptor
+
+        def exhaust_staging(path: Path) -> tuple[int, tuple[int, int]]:
+            if path.name.endswith(".partial"):
+                raise OSError(errno.ENOSPC, "synthetic full destination")
+            return real_create(path)
+
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            backup = _write_backup(base)
+            rows, plaintext = _row(backup)
+            with (
+                mock.patch(
+                    "tvtime_extractor.extract._create_private_staging_descriptor",
+                    side_effect=exhaust_staging,
+                ),
+                self.assertRaises(InsufficientSpaceError),
+            ):
+                extract_backup(
+                    backup_directory=backup,
+                    output_directory=base / "output",
+                    passphrase="synthetic password",
+                    dependency_loader=_loader([], rows=rows, plaintext=plaintext),
+                )
+
+    def test_invalid_padding_remains_a_failure_and_is_never_promoted(self) -> None:
+        from Crypto.Cipher import AES
+
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            backup = _write_backup(base)
+            rows, plaintext = _row(backup)
+            file_id = str(rows[0][0])
+            (backup / file_id[:2] / file_id).write_bytes(
+                AES.new(b"K" * 32, AES.MODE_CBC, iv=b"\x00" * 16).encrypt(b"X" * 15 + b"\x00")
+            )
+            result = extract_backup(
+                backup_directory=backup,
+                output_directory=base / "output",
+                passphrase="synthetic password",
+                dependency_loader=_loader([], rows=rows, plaintext=plaintext),
+            )
+
+            self.assertEqual(self._single_failure_category(result), "padding_failure")
+            self.assertFalse(
+                (
+                    result.extraction_root / "raw" / PRIMARY_DOMAIN / "Documents" / "recovered.bin"
+                ).exists()
+            )
+
+    def test_space_preflight_uses_ciphertext_as_the_output_upper_bound(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            backup = _write_backup(base)
+            rows, plaintext = _row(backup)
+            file_id, domain, relative_path, metadata = rows[0]
+            rows[0] = (file_id, domain, relative_path, {**metadata, "filesize": 1})
+            minimum_headroom = 64 * 1024 * 1024
+            with (
+                mock.patch(
+                    "tvtime_extractor.extract.shutil.disk_usage",
+                    side_effect=(
+                        mock.Mock(free=1024 * 1024 * 1024),
+                        mock.Mock(free=minimum_headroom + 24),
+                    ),
+                ),
+                self.assertRaises(InsufficientSpaceError),
+            ):
+                extract_backup(
+                    backup_directory=backup,
+                    output_directory=base / "output",
+                    passphrase="synthetic password",
+                    dependency_loader=_loader([], rows=rows, plaintext=plaintext),
+                )
+
+    def test_retained_manifest_is_promoted_from_a_held_private_descriptor(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            base = Path(temporary)
+            backup = _write_backup(base)
+            result = extract_backup(
+                backup_directory=backup,
+                output_directory=base / "output",
+                passphrase="synthetic password",
+                include_decrypted_manifest=True,
+                dependency_loader=_loader([], rows=[], plaintext={}),
+            )
+            retained = result.extraction_root / "manifest" / "Manifest.decrypted.db"
+            retained_bytes = retained.read_bytes()
+            self.assertTrue(retained_bytes.startswith(b"SQLite format 3\x00"))
+            self.assertEqual(
+                result.summary["manifest_sha256"],
+                hashlib.sha256(retained_bytes).hexdigest(),
+            )
+
     def test_direct_extract_status_is_byte_bounded_before_output_creation(self) -> None:
         def finished_payload(byte_size: int) -> bytes:
             base = plistlib.dumps({"SnapshotState": "finished"}, fmt=plistlib.FMT_XML)
@@ -519,9 +1075,17 @@ class ExtractionLifecycleSecurityTests(unittest.TestCase):
             marker = read_json_regular(result.extraction_root / "metadata" / "run_state.json")
             self.assertEqual(marker["status"], "complete")
             self.assertEqual(instance.run_state_at_cleanup, "incomplete")
+            self.assertIsNotNone(instance.connection)
+            assert instance.connection is not None
             self.assertTrue(instance.connection.closed)
             self.assertEqual(instance.cleanup_calls, 1)
-            self.assertTrue(instance.decrypted_from_private_snapshot)
+            self.assertFalse(instance.path_writer_called)
+            self.assertEqual(
+                (
+                    result.extraction_root / "raw" / PRIMARY_DOMAIN / "Documents" / "recovered.bin"
+                ).read_bytes(),
+                b"recovered",
+            )
             self.assertIsNone(instance._passphrase)
             self.assertIsNone(instance._keybag)
             self.assertFalse((result.extraction_root / ".tmp").exists())
@@ -568,6 +1132,8 @@ class ExtractionLifecycleSecurityTests(unittest.TestCase):
             self.assertEqual(marker["status"], "incomplete")
             self.assertEqual(list((extraction / "raw").rglob("*")), [])
             self.assertEqual(len(instances), 1)
+            self.assertIsNotNone(instances[0].connection)
+            assert instances[0].connection is not None
             self.assertTrue(instances[0].connection.closed)
 
     def test_non_integer_declared_sizes_are_rejected_without_coercion(self) -> None:
@@ -616,6 +1182,7 @@ class ExtractionLifecycleSecurityTests(unittest.TestCase):
                         ),
                     )
 
+    @unittest.skipIf(os.name == "nt", "Windows source handles deny concurrent mutation")
     def test_source_hashing_detects_in_place_race_even_when_size_and_mtime_are_restored(
         self,
     ) -> None:

--- a/tests/test_service_protocol_e2e.py
+++ b/tests/test_service_protocol_e2e.py
@@ -6,6 +6,7 @@ import os
 import plistlib
 import queue
 import shutil
+import sqlite3
 import stat
 import struct
 import subprocess
@@ -92,15 +93,7 @@ class _FilePlist:
 
 class _Keybag:
     def unwrapKeyForClass(self, _protection_class: object, _wrapped: object) -> bytes:
-        return b"unwrapped"
-
-
-class _Connection:
-    def __init__(self) -> None:
-        self.closed = False
-
-    def close(self) -> None:
-        self.closed = True
+        return b"K" * 32
 
 
 class _EndToEndBackup:
@@ -122,10 +115,11 @@ class _EndToEndBackup:
         self._manifest_plist = {"synthetic": True}
         self._temporary_folder = tempfile.mkdtemp(prefix="e2e-dependency-")
         self._temp_decrypted_manifest_db_path = str(Path(self._temporary_folder) / "Manifest.db")
-        Path(self._temp_decrypted_manifest_db_path).write_bytes(b"private manifest")
-        self.connection = _Connection()
-        self._temp_manifest_db_conn = self.connection
+        self._temp_manifest_db_conn = None
         self.cleanup_calls = 0
+
+    def _read_and_unlock_keybag(self) -> None:
+        self._manifest_plist = {"ManifestKey": struct.pack("<l", 1) + b"wrapped"}
 
     def test_decryption(self) -> None:
         return None
@@ -141,9 +135,7 @@ class _EndToEndBackup:
         file_plist: _FilePlist,
         output_filepath: str,
     ) -> None:
-        if key != b"unwrapped":
-            raise AssertionError("unexpected synthetic key")
-        Path(output_filepath).write_bytes(self.plaintext[file_id])
+        raise AssertionError("the dependency path-only writer must not be called")
 
     def _cleanup(self) -> None:
         self.cleanup_calls += 1
@@ -151,6 +143,8 @@ class _EndToEndBackup:
 
 
 def _write_completed_encrypted_backup(base: Path) -> Path:
+    from Crypto.Cipher import AES
+
     backup = base / "backup"
     backup.mkdir()
     with (backup / "Manifest.plist").open("wb") as handle:
@@ -158,7 +152,27 @@ def _write_completed_encrypted_backup(base: Path) -> Path:
             {"IsEncrypted": True, "Date": datetime(2025, 1, 1, tzinfo=timezone.utc)},
             handle,
         )
-    (backup / "Manifest.db").write_bytes(b"synthetic encrypted manifest")
+    plaintext_manifest = base / "synthetic-manifest.db"
+    connection = sqlite3.connect(plaintext_manifest)
+    try:
+        connection.execute(
+            "CREATE TABLE Files (fileID TEXT, domain TEXT, relativePath TEXT, "
+            "flags INTEGER, file BLOB)"
+        )
+        connection.execute(
+            "INSERT INTO Files VALUES (?, ?, ?, ?, ?)",
+            ("0" * 40, PRIMARY_DOMAIN, "Documents/synthetic.db", 1, b"synthetic"),
+        )
+        connection.commit()
+    finally:
+        connection.close()
+    manifest_bytes = plaintext_manifest.read_bytes()
+    plaintext_manifest.unlink()
+    if len(manifest_bytes) % 16:
+        raise AssertionError("synthetic SQLite manifest was not block aligned")
+    (backup / "Manifest.db").write_bytes(
+        AES.new(b"K" * 32, AES.MODE_CBC, iv=b"\x00" * 16).encrypt(manifest_bytes)
+    )
     with (backup / "Status.plist").open("wb") as handle:
         plistlib.dump(
             {
@@ -196,6 +210,8 @@ class RecoveryServiceEndToEndTests(unittest.TestCase):
     def test_full_synthetic_recovery_runs_extraction_analysis_report_and_atomic_markers(
         self,
     ) -> None:
+        from Crypto.Cipher import AES
+
         with tempfile.TemporaryDirectory() as temporary:
             base = Path(temporary)
             template = create_synthetic_extraction(base / "template")
@@ -219,7 +235,12 @@ class RecoveryServiceEndToEndTests(unittest.TestCase):
                 )
                 encrypted = backup / file_id[:2] / file_id
                 encrypted.parent.mkdir(exist_ok=True)
-                encrypted.write_bytes(b"synthetic encrypted payload")
+                padding_size = 16 - len(payload) % 16
+                encrypted.write_bytes(
+                    AES.new(b"K" * 32, AES.MODE_CBC, iv=b"\x00" * 16).encrypt(
+                        payload + bytes([padding_size]) * padding_size
+                    )
+                )
 
             instances: list[_EndToEndBackup] = []
 
@@ -318,7 +339,7 @@ class RecoveryServiceEndToEndTests(unittest.TestCase):
             self.assertFalse((extraction / ".tmp").exists())
             self.assertFalse((extraction / ".analysis-incomplete").exists())
             self.assertFalse((extraction / ".report-incomplete").exists())
-            self.assertTrue(instances[0].connection.closed)
+            self.assertIsNone(instances[0]._temp_manifest_db_conn)
             self.assertEqual(instances[0].cleanup_calls, 1)
             completed_stages = [
                 event.stage.value for event in events if event.kind.value == "completed"
@@ -461,7 +482,12 @@ class RecoveryServiceEndToEndTests(unittest.TestCase):
 
                 def synthetic_extract(**kwargs: object) -> ExtractionResult:
                     source_descriptor = int(kwargs["source_root_descriptor"])
-                    self.assertTrue(stat.S_ISDIR(os.fstat(source_descriptor).st_mode))
+                    if os.name == "nt":
+                        from tvtime_extractor.windows_native import handle_information
+
+                        self.assertTrue(handle_information(source_descriptor).is_directory)
+                    else:
+                        self.assertTrue(stat.S_ISDIR(os.fstat(source_descriptor).st_mode))
                     captured.update(kwargs)
                     return ExtractionResult(
                         Path("TVTime-Extraction"),
@@ -658,6 +684,7 @@ class RecoveryServiceEndToEndTests(unittest.TestCase):
             )
             self.assertTrue(output.is_dir())
 
+    @unittest.skipIf(os.name == "nt", "Windows holds the source root without delete sharing")
     def test_source_root_swap_after_revalidation_stops_before_output_or_stages(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             base = Path(temporary)

--- a/tests/test_smoke_packaged_helper.py
+++ b/tests/test_smoke_packaged_helper.py
@@ -82,6 +82,7 @@ class ProcessCleanupTests(unittest.TestCase):
 
 
 class StandaloneHelperSignatureTests(unittest.TestCase):
+    @unittest.skipIf(os.name == "nt", "packaged macOS helper descriptors are POSIX-only")
     def test_smoke_maps_and_restores_reserved_destination_descriptor(self) -> None:
         try:
             before = os.fstat(smoke_packaged_helper.DESTINATION_PARENT_FILE_DESCRIPTOR)

--- a/tests/test_windows_native.py
+++ b/tests/test_windows_native.py
@@ -1,0 +1,239 @@
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import os
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from tvtime_extractor import windows_native
+from tvtime_extractor.safety import _windows_close_handle, _windows_open_locked_directory
+
+
+class WindowsNativeUnitTests(unittest.TestCase):
+    def test_component_validation_rejects_traversal_and_reserved_separators(self) -> None:
+        for value in ("", ".", "..", "nested/name", "nested\\name", "bad:name", "bad\x00name"):
+            with self.subTest(value=value), self.assertRaises(windows_native.WindowsNativeError):
+                windows_native.validate_component(value)
+        self.assertEqual(windows_native.validate_component("synthetic-output"), "synthetic-output")
+
+    def test_collision_status_is_sanitized_without_loading_windows_libraries(self) -> None:
+        error = windows_native._ntstatus_error(
+            ctypes.c_long(windows_native.STATUS_OBJECT_NAME_COLLISION).value,
+            "synthetic collision",
+        )
+        self.assertIsInstance(error, windows_native.WindowsObjectExistsError)
+        self.assertEqual(error.ntstatus, windows_native.STATUS_OBJECT_NAME_COLLISION)
+
+    def test_rename_structure_places_variable_name_at_the_documented_field_offset(self) -> None:
+        self.assertLess(
+            windows_native._FILE_RENAME_INFO.FileName.offset,
+            ctypes.sizeof(windows_native._FILE_RENAME_INFO),
+        )
+
+    def test_private_volume_probe_rejects_non_ntfs_and_missing_acl_support(self) -> None:
+        for capabilities in (
+            windows_native.WindowsVolumeCapabilities(
+                filesystem_name="exFAT",
+                filesystem_flags=windows_native.FILE_PERSISTENT_ACLS,
+            ),
+            windows_native.WindowsVolumeCapabilities(
+                filesystem_name="ReFS",
+                filesystem_flags=windows_native.FILE_PERSISTENT_ACLS,
+            ),
+            windows_native.WindowsVolumeCapabilities(
+                filesystem_name="NTFS",
+                filesystem_flags=0,
+            ),
+        ):
+            with (
+                self.subTest(capabilities=capabilities),
+                mock.patch.object(
+                    windows_native,
+                    "volume_capabilities",
+                    return_value=capabilities,
+                ),
+                self.assertRaises(windows_native.WindowsUnsupportedError),
+            ):
+                windows_native.require_private_ntfs_volume(123)
+
+
+@unittest.skipUnless(os.name == "nt", "real NTFS capability regression")
+class WindowsNativeNtfsTests(unittest.TestCase):
+    def setUp(self) -> None:
+        windows_native.require_supported_runtime()
+
+    def test_atomic_fresh_root_has_one_winner_and_blocks_rename(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            parent = Path(temporary)
+            parent_handle = -1
+            winner_handle = -1
+            try:
+                parent_handle, _identity = _windows_open_locked_directory(parent, writable=True)
+                try:
+                    windows_native.require_private_ntfs_volume(parent_handle)
+                except windows_native.WindowsUnsupportedError as exc:
+                    self.skipTest(str(exc))
+
+                outcomes: list[tuple[str, int]] = []
+                outcome_lock = threading.Lock()
+
+                def create() -> None:
+                    try:
+                        handle = windows_native.create_fresh_directory(
+                            parent_handle,
+                            "synthetic-fresh-root",
+                        )
+                    except windows_native.WindowsObjectExistsError:
+                        result = ("collision", -1)
+                    else:
+                        result = ("created", handle)
+                    with outcome_lock:
+                        outcomes.append(result)
+
+                threads = [threading.Thread(target=create) for _index in range(2)]
+                for thread in threads:
+                    thread.start()
+                for thread in threads:
+                    thread.join()
+
+                self.assertEqual(
+                    sorted(label for label, _handle in outcomes), ["collision", "created"]
+                )
+                winner_handle = next(handle for label, handle in outcomes if label == "created")
+                fresh = parent / "synthetic-fresh-root"
+                visible_handle, visible_identity = _windows_open_locked_directory(fresh)
+                try:
+                    self.assertEqual(
+                        windows_native.handle_information(winner_handle).identity,
+                        visible_identity,
+                    )
+                finally:
+                    _windows_close_handle(visible_handle)
+                windows_native.validate_private_acl(winner_handle)
+                with self.assertRaises(OSError):
+                    fresh.rmdir()
+                with self.assertRaises(OSError):
+                    fresh.rename(parent / "renamed-root")
+                with self.assertRaises(OSError):
+                    parent.rename(parent.with_name(f"{parent.name}-renamed"))
+            finally:
+                if winner_handle >= 0:
+                    windows_native.close_handle(winner_handle)
+                if parent_handle >= 0:
+                    _windows_close_handle(parent_handle)
+
+    def test_staging_file_denies_mutation_and_promotes_without_replace(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            parent = Path(temporary)
+            parent_handle = -1
+            root_handle = -1
+            descriptor = -1
+            collision_descriptor = -1
+            try:
+                parent_handle, _identity = _windows_open_locked_directory(parent, writable=True)
+                try:
+                    windows_native.require_private_ntfs_volume(parent_handle)
+                except windows_native.WindowsUnsupportedError as exc:
+                    self.skipTest(str(exc))
+                root_handle = windows_native.create_fresh_directory(
+                    parent_handle,
+                    "synthetic-root",
+                )
+                staging_handle = windows_native.create_relative_regular_file_path(
+                    root_handle,
+                    ("stage.partial",),
+                    temporary=True,
+                )
+                descriptor = windows_native.handle_to_file_descriptor(
+                    staging_handle,
+                    flags=os.O_RDWR | getattr(os, "O_BINARY", 0),
+                )
+                payload = b"synthetic descriptor payload"
+                os.write(descriptor, payload)
+                os.fsync(descriptor)
+                with self.assertRaises(OSError):
+                    (parent / "synthetic-root" / "stage.partial").write_bytes(b"changed")
+                with self.assertRaises(OSError):
+                    (parent / "synthetic-root" / "stage.partial").unlink()
+
+                native_handle = int(__import__("msvcrt").get_osfhandle(descriptor))
+                windows_native.rename_handle_relative(
+                    native_handle,
+                    root_handle,
+                    ("final.bin",),
+                    replace=False,
+                )
+                os.lseek(descriptor, 0, os.SEEK_SET)
+                self.assertEqual(os.read(descriptor, len(payload) + 1), payload)
+                os.close(descriptor)
+                descriptor = -1
+                self.assertEqual((parent / "synthetic-root" / "final.bin").read_bytes(), payload)
+
+                collision_handle = windows_native.create_relative_regular_file_path(
+                    root_handle,
+                    ("collision.partial",),
+                    temporary=True,
+                )
+                collision_descriptor = windows_native.handle_to_file_descriptor(
+                    collision_handle,
+                    flags=os.O_RDWR | getattr(os, "O_BINARY", 0),
+                )
+                collision_native = int(__import__("msvcrt").get_osfhandle(collision_descriptor))
+                with self.assertRaises(windows_native.WindowsObjectExistsError):
+                    windows_native.rename_handle_relative(
+                        collision_native,
+                        root_handle,
+                        ("final.bin",),
+                        replace=False,
+                    )
+            finally:
+                for file_descriptor in (collision_descriptor, descriptor):
+                    if file_descriptor >= 0:
+                        with contextlib.suppress(OSError):
+                            os.close(file_descriptor)
+                if root_handle >= 0:
+                    windows_native.close_handle(root_handle)
+                if parent_handle >= 0:
+                    _windows_close_handle(parent_handle)
+
+    def test_reparse_component_is_rejected_when_symlink_creation_is_available(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            parent = Path(temporary)
+            parent_handle = -1
+            root_handle = -1
+            try:
+                parent_handle, _identity = _windows_open_locked_directory(parent, writable=True)
+                try:
+                    windows_native.require_private_ntfs_volume(parent_handle)
+                except windows_native.WindowsUnsupportedError as exc:
+                    self.skipTest(str(exc))
+                root_handle = windows_native.create_fresh_directory(
+                    parent_handle,
+                    "synthetic-root",
+                )
+                target = parent / "synthetic-target"
+                target.mkdir()
+                link = parent / "synthetic-root" / "synthetic-link"
+                try:
+                    os.symlink(target, link, target_is_directory=True)
+                except OSError as exc:
+                    self.skipTest(f"directory symlink creation is unavailable: {exc.winerror}")
+                with self.assertRaises(windows_native.WindowsNativeError):
+                    windows_native.open_relative_directory(
+                        root_handle,
+                        "synthetic-link",
+                        writable=False,
+                    )
+            finally:
+                if root_handle >= 0:
+                    windows_native.close_handle(root_handle)
+                if parent_handle >= 0:
+                    _windows_close_handle(parent_handle)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tvtime_extractor/analyze.py
+++ b/tvtime_extractor/analyze.py
@@ -28,6 +28,7 @@ from .integrity import reconcile_raw_tree, source_snapshot_from_mapping
 from .safety import (
     MAXIMUM_COMPLETION_MARKER_BYTES,
     anchored_existing_extraction_root,
+    create_private_file_descriptor,
     iter_regular_files,
     prepare_analysis_layout,
     private_source_id,
@@ -532,9 +533,6 @@ def _copy_sqlite_snapshot_file(
     remaining_total_bytes: int,
     require_private_source: bool,
 ) -> int:
-    destination_flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
-    destination_flags |= getattr(os, "O_BINARY", 0)
-    destination_flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
     destination_descriptor = -1
     total = 0
     try:
@@ -544,7 +542,10 @@ def _copy_sqlite_snapshot_file(
         ) as (source_handle, opened_source):
             if not _same_sqlite_source(source_before, opened_source):
                 raise TVTimeError("A recovered SQLite database changed while it was opened.")
-            destination_descriptor = os.open(destination, destination_flags, 0o600)
+            destination_descriptor = create_private_file_descriptor(
+                destination,
+                exclusive=True,
+            )
             if os.name != "nt":
                 os.fchmod(destination_descriptor, 0o600)
             require_private_descriptor(destination_descriptor, expected_type=stat.S_IFREG)

--- a/tvtime_extractor/extract.py
+++ b/tvtime_extractor/extract.py
@@ -8,16 +8,20 @@ import os
 import plistlib
 import secrets
 import shutil
+import sqlite3
 import stat
+import struct
 import sys
 import tempfile
 from collections.abc import Callable
 from contextlib import ExitStack, contextmanager, redirect_stderr, redirect_stdout, suppress
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
+from . import windows_native as _windows_native
 from .errors import (
     AppDataMissingError,
     BackupPasswordError,
@@ -34,13 +38,18 @@ from .safety import (
     EXTRACTION_RUN_STATE_CONTRACT,
     EXTRACTION_RUN_STATE_SCHEMA_VERSION,
     ExtractionLayout,
+    _windows_close_handle,
+    _windows_directory_identity,
+    _windows_open_locked_directory,
     anchored_bound_output_root,
+    create_private_file_descriptor,
     harden_private_descriptor,
     held_destination_parent,
     no_link_absolute_path,
     prepare_anchored_extraction_layout,
     prepare_extraction_layout,
-    promote_file_no_replace_atomic,
+    promote_open_file_no_replace_atomic,
+    regular_binary_reader,
     require_fresh_output_platform_support,
     require_private_descriptor,
     safe_domain_component,
@@ -70,6 +79,59 @@ MAXIMUM_MANIFEST_CELL_BYTES = 4 * 1024 * 1024
 MAXIMUM_MANIFEST_COMBINED_BYTES = 256 * 1024 * 1024
 MAXIMUM_STATUS_PLIST_BYTES = 1024 * 1024
 _MANIFEST_FETCH_BATCH_ROWS = 256
+
+
+class _SelectedFileFailureCategory(str, Enum):
+    INVALID_MANIFEST_METADATA = "invalid_manifest_metadata"
+    UNSAFE_PATH = "unsafe_path"
+    SOURCE_UNAVAILABLE = "source_unavailable"
+    SOURCE_CHANGED = "source_changed"
+    MISSING_ENCRYPTION_KEY = "missing_encryption_key"
+    KEY_UNWRAP_FAILURE = "key_unwrap_failure"
+    CIPHERTEXT_INVALID = "ciphertext_invalid"
+    PADDING_FAILURE = "padding_failure"
+    SIZE_MISMATCH = "size_mismatch"
+    STAGING_FAILURE = "staging_failure"
+    PROMOTION_FAILURE = "promotion_failure"
+    UNRECOGNIZED_FAILURE = "unrecognized_failure"
+
+
+class _SelectedFilePhase(Enum):
+    MANIFEST_METADATA = "manifest_metadata"
+    SOURCE = "source"
+    KEY_UNWRAP = "key_unwrap"
+    DECRYPTION = "decryption"
+    STAGING = "staging"
+    PROMOTION = "promotion"
+
+
+class _SelectedFileCopyFailure(Exception):
+    """A content-free internal failure classification for one selected payload."""
+
+    def __init__(self, category: _SelectedFileFailureCategory) -> None:
+        super().__init__(DEPENDENCY_FILE_FAILURE_MESSAGE)
+        self.category = category
+
+
+class _DescriptorDecryptionFailure(Exception):
+    """A content-free AES-CBC validation result shared by manifest and file decryptors."""
+
+    def __init__(self, category: _SelectedFileFailureCategory) -> None:
+        super().__init__(DEPENDENCY_FILE_FAILURE_MESSAGE)
+        self.category = category
+
+
+def _phase_failure_category(phase: _SelectedFilePhase) -> _SelectedFileFailureCategory:
+    return {
+        _SelectedFilePhase.MANIFEST_METADATA: (
+            _SelectedFileFailureCategory.INVALID_MANIFEST_METADATA
+        ),
+        _SelectedFilePhase.SOURCE: _SelectedFileFailureCategory.SOURCE_UNAVAILABLE,
+        _SelectedFilePhase.KEY_UNWRAP: _SelectedFileFailureCategory.KEY_UNWRAP_FAILURE,
+        _SelectedFilePhase.DECRYPTION: _SelectedFileFailureCategory.UNRECOGNIZED_FAILURE,
+        _SelectedFilePhase.STAGING: _SelectedFileFailureCategory.STAGING_FAILURE,
+        _SelectedFilePhase.PROMOTION: _SelectedFileFailureCategory.PROMOTION_FAILURE,
+    }[phase]
 
 
 @dataclass(frozen=True)
@@ -126,6 +188,125 @@ def _same_source_metadata(before: os.stat_result, after: os.stat_result) -> bool
     return all(getattr(before, field, 0) == getattr(after, field, 0) for field in fields)
 
 
+def _windows_filetime_ns(value: int) -> int:
+    # Windows FILETIME is 100 ns since 1601-01-01; Python timestamps use the Unix epoch.
+    return max(0, (value - 116_444_736_000_000_000) * 100)
+
+
+def _windows_backup_snapshot(
+    information: _windows_native.WindowsHandleInformation,
+    *,
+    sha256: str,
+) -> BackupFileSnapshot:
+    timestamp_ns = _windows_filetime_ns(information.last_write_time)
+    return BackupFileSnapshot(
+        mode=stat.S_IFREG,
+        size=information.byte_size,
+        modified_ns=timestamp_ns,
+        changed_ns=timestamp_ns,
+        device=information.identity[0],
+        inode=information.identity[1],
+        sha256=sha256,
+    )
+
+
+def _windows_source_payload(
+    path: Path,
+    *,
+    source_root_handle: int,
+    snapshot_destination: Path | None = None,
+    maximum_bytes: int | None = None,
+    retain_payload: bool = False,
+) -> tuple[BackupFileSnapshot, bytes | None]:
+    if path.is_absolute() or not path.parts or any(part in {"", ".", ".."} for part in path.parts):
+        raise UnsafePathError("A handle-rooted Windows source path was invalid.")
+    handle = -1
+    descriptor = -1
+    destination_descriptor = -1
+    payload = bytearray() if retain_payload else None
+    digest = hashlib.sha256()
+    byte_count = 0
+    before: _windows_native.WindowsHandleInformation | None = None
+    try:
+        handle = _windows_native.open_relative_path(source_root_handle, path.parts)
+        before = _windows_native.handle_information(handle)
+        descriptor = _windows_native.handle_to_file_descriptor(
+            handle,
+            flags=os.O_RDONLY | getattr(os, "O_BINARY", 0),
+        )
+        handle = -1
+        if maximum_bytes is not None and (
+            before.byte_size <= 0 or before.byte_size > maximum_bytes
+        ):
+            raise UnsafePathError("A required source file had an unsafe byte size.")
+        if snapshot_destination is not None:
+            secure_directory(snapshot_destination.parent)
+            destination_descriptor = create_private_file_descriptor(
+                snapshot_destination,
+                exclusive=True,
+            )
+            harden_private_descriptor(
+                destination_descriptor,
+                expected_type=stat.S_IFREG,
+                mode=0o600,
+            )
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            byte_count += len(chunk)
+            if maximum_bytes is not None and byte_count > maximum_bytes:
+                raise UnsafePathError("A required source file had an unsafe byte size.")
+            digest.update(chunk)
+            if payload is not None:
+                payload.extend(chunk)
+            if destination_descriptor >= 0:
+                remaining = memoryview(chunk)
+                while remaining:
+                    written = os.write(destination_descriptor, remaining)
+                    if written <= 0:
+                        raise OSError("short encrypted snapshot write")
+                    remaining = remaining[written:]
+        if destination_descriptor >= 0:
+            os.fsync(destination_descriptor)
+        import msvcrt
+
+        native_descriptor_handle = int(msvcrt.get_osfhandle(descriptor))
+        after = _windows_native.handle_information(native_descriptor_handle)
+        visible_handle = _windows_native.open_relative_path(source_root_handle, path.parts)
+        try:
+            visible = _windows_native.handle_information(visible_handle)
+        finally:
+            _windows_native.close_handle(visible_handle)
+        if before != after or after != visible or byte_count != after.byte_size:
+            raise SourceChangedError(
+                "A selected encrypted source payload changed during verification. Preserve the "
+                "incomplete output and retry from a completed, disconnected backup."
+            )
+        if snapshot_destination is not None:
+            visible_destination = snapshot_destination.lstat()
+            opened_destination = os.fstat(destination_descriptor)
+            if _metadata_identity(visible_destination) != _metadata_identity(opened_destination):
+                raise UnsafePathError(
+                    "A private Windows snapshot changed while it was being written."
+                )
+        return _windows_backup_snapshot(after, sha256=digest.hexdigest()), (
+            bytes(payload) if payload is not None else None
+        )
+    except _windows_native.WindowsNativeError as exc:
+        raise SourceChangedError(
+            "A selected encrypted source payload was unavailable. Preserve the incomplete output "
+            "and retry from a completed, disconnected backup."
+        ) from exc
+    finally:
+        if destination_descriptor >= 0:
+            os.close(destination_descriptor)
+        if descriptor >= 0:
+            os.close(descriptor)
+        elif handle >= 0:
+            _windows_native.close_handle(handle)
+
+
 def _source_payload_state(
     path: Path,
     *,
@@ -133,6 +314,71 @@ def _source_payload_state(
     source_root_descriptor: int | None = None,
 ) -> BackupFileSnapshot:
     """Hash/copy one source payload through a stable, descriptor-rooted no-follow chain."""
+
+    if os.name == "nt" and source_root_descriptor is not None:
+        snapshot, _payload = _windows_source_payload(
+            path,
+            source_root_handle=source_root_descriptor,
+            snapshot_destination=snapshot_destination,
+        )
+        return snapshot
+    if os.name == "nt":
+        digest = hashlib.sha256()
+        byte_count = 0
+        destination_descriptor = -1
+        try:
+            with regular_binary_reader(path) as (source, metadata):
+                if snapshot_destination is not None:
+                    secure_directory(snapshot_destination.parent)
+                    destination_descriptor = create_private_file_descriptor(
+                        snapshot_destination,
+                        exclusive=True,
+                        read_write=False,
+                        temporary=True,
+                    )
+                while True:
+                    chunk = source.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    byte_count += len(chunk)
+                    digest.update(chunk)
+                    if destination_descriptor >= 0:
+                        remaining = memoryview(chunk)
+                        while remaining:
+                            written = os.write(destination_descriptor, remaining)
+                            if written <= 0:
+                                raise OSError("short encrypted snapshot write")
+                            remaining = remaining[written:]
+                if byte_count != metadata.st_size:
+                    raise SourceChangedError(
+                        "A selected encrypted source payload changed during verification. "
+                        "Preserve the incomplete output and retry from a completed, "
+                        "disconnected backup."
+                    )
+                if destination_descriptor >= 0:
+                    os.fsync(destination_descriptor)
+                snapshot = BackupFileSnapshot(
+                    mode=int(metadata.st_mode),
+                    size=int(metadata.st_size),
+                    modified_ns=int(metadata.st_mtime_ns),
+                    changed_ns=int(metadata.st_ctime_ns),
+                    device=int(metadata.st_dev),
+                    inode=int(metadata.st_ino),
+                    sha256=digest.hexdigest(),
+                )
+        except OSError as exc:
+            if is_insufficient_space_error(exc):
+                raise insufficient_space_error() from exc
+            raise SourceChangedError(
+                "A selected encrypted source payload changed during verification. Preserve the "
+                "incomplete output and retry from a completed, disconnected backup."
+            ) from exc
+        finally:
+            if destination_descriptor >= 0:
+                os.close(destination_descriptor)
+        if snapshot_destination is not None:
+            secure_file(snapshot_destination)
+        return snapshot
 
     parent_descriptor = -1
     source_name: str | Path = path
@@ -290,6 +536,82 @@ def _finished_status_state(
 ) -> BackupFileSnapshot:
     """Read and hash the exact Status.plist bytes that assert a finished snapshot."""
 
+    if os.name == "nt" and source_root_descriptor is not None:
+        try:
+            snapshot, payload = _windows_source_payload(
+                path,
+                source_root_handle=source_root_descriptor,
+                maximum_bytes=MAXIMUM_STATUS_PLIST_BYTES,
+                retain_payload=True,
+            )
+        except (SourceChangedError, UnsafePathError) as exc:
+            raise BackupUnfinishedError(
+                "The backup status could not be read safely. Use a completed, disconnected backup."
+            ) from exc
+        try:
+            value = plistlib.loads(payload or b"")
+        except plistlib.InvalidFileException as exc:
+            raise BackupUnfinishedError(
+                "The backup status could not be validated. Use a completed, disconnected backup."
+            ) from exc
+        if (
+            not isinstance(value, dict)
+            or str(value.get("SnapshotState") or "").strip().casefold() != "finished"
+        ):
+            raise BackupUnfinishedError(
+                "The selected backup is not marked finished. Let Finder or Apple Devices finish "
+                "the backup, then eject the phone before recovery."
+            )
+        return snapshot
+    if os.name == "nt":
+        payload = bytearray()
+        try:
+            with regular_binary_reader(path) as (source, metadata):
+                if metadata.st_size <= 0 or metadata.st_size > MAXIMUM_STATUS_PLIST_BYTES:
+                    raise BackupUnfinishedError(
+                        "The backup status was not a bounded regular file. Use a completed, "
+                        "disconnected backup."
+                    )
+                while len(payload) <= MAXIMUM_STATUS_PLIST_BYTES:
+                    chunk = source.read(
+                        min(1024 * 1024, MAXIMUM_STATUS_PLIST_BYTES + 1 - len(payload))
+                    )
+                    if not chunk:
+                        break
+                    payload.extend(chunk)
+        except UnsafePathError as exc:
+            raise BackupUnfinishedError(
+                "The backup status could not be read safely. Use a completed, disconnected backup."
+            ) from exc
+        try:
+            value = plistlib.loads(bytes(payload))
+        except plistlib.InvalidFileException as exc:
+            raise BackupUnfinishedError(
+                "The backup status could not be validated. Use a completed, disconnected backup."
+            ) from exc
+        if (
+            not isinstance(value, dict)
+            or str(value.get("SnapshotState") or "").strip().casefold() != "finished"
+        ):
+            raise BackupUnfinishedError(
+                "The selected backup is not marked finished. Let Finder or Apple Devices finish "
+                "the backup, then eject the phone before recovery."
+            )
+        if len(payload) != metadata.st_size or len(payload) > MAXIMUM_STATUS_PLIST_BYTES:
+            raise SourceChangedError(
+                "The backup status changed during verification. Retry from a completed, "
+                "disconnected backup."
+            )
+        return BackupFileSnapshot(
+            mode=int(metadata.st_mode),
+            size=int(metadata.st_size),
+            modified_ns=int(metadata.st_mtime_ns),
+            changed_ns=int(metadata.st_ctime_ns),
+            device=int(metadata.st_dev),
+            inode=int(metadata.st_ino),
+            sha256=hashlib.sha256(payload).hexdigest(),
+        )
+
     try:
         if source_root_descriptor is not None:
             if path.is_absolute() or path.parts != (path.name,):
@@ -405,6 +727,27 @@ def _require_bound_backup_root(
 ) -> None:
     """Require one held no-follow directory descriptor to remain the visible backup root."""
 
+    if os.name == "nt":
+        visible_handle = -1
+        try:
+            if _windows_directory_identity(descriptor) != expected_identity:
+                raise SourceChangedError(
+                    "The selected backup root changed while recovery was preparing to use it."
+                )
+            visible_handle, visible_identity = _windows_open_locked_directory(backup)
+            if visible_identity != expected_identity:
+                raise SourceChangedError(
+                    "The selected backup root changed while recovery was preparing to use it."
+                )
+            return
+        except UnsafePathError as exc:
+            raise SourceChangedError(
+                "The selected backup root changed while recovery was preparing to use it."
+            ) from exc
+        finally:
+            if visible_handle >= 0:
+                _windows_close_handle(visible_handle)
+
     try:
         opened = os.fstat(descriptor)
         visible = backup.lstat()
@@ -439,6 +782,22 @@ def _held_backup_root(
         raise SourceChangedError("The selected backup root could not be opened safely.") from exc
     if _is_link_or_reparse(before) or not stat.S_ISDIR(before.st_mode):
         raise UnsafePathError("The selected backup root was not a regular directory.")
+    if os.name == "nt":
+        handle = -1
+        try:
+            handle, identity = _windows_open_locked_directory(backup)
+            if expected_identity is not None and identity != expected_identity:
+                raise SourceChangedError("The selected backup root changed while it was opened.")
+            _require_bound_backup_root(
+                backup,
+                descriptor=handle,
+                expected_identity=identity,
+            )
+            yield handle, identity, backup
+        finally:
+            if handle >= 0:
+                _windows_close_handle(handle)
+        return
     flags = os.O_RDONLY | getattr(os, "O_DIRECTORY", 0)
     flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
     descriptor = -1
@@ -547,6 +906,14 @@ def _dispose_dependency(backup: Any, temp_root: Path, *, strict: bool) -> None:
             close_failed = True
         with suppress(Exception):
             backup._temp_manifest_db_conn = None
+    manifest_lock = getattr(backup, "_tvtime_manifest_lock", None)
+    if manifest_lock is not None:
+        try:
+            manifest_lock.__exit__(None, None, None)
+        except Exception:
+            close_failed = True
+        with suppress(Exception):
+            backup._tvtime_manifest_lock = None
 
     temporary_folder = getattr(backup, "_temporary_folder", "")
     try:
@@ -607,9 +974,7 @@ def _anchored_dependency_temporary_directories(temp_root: Path):
         for _attempt in range(128):
             name = f"{prefix or 'tmp'}{secrets.token_hex(16)}{suffix or ''}"
             candidate = safe_join(parent, name)
-            try:
-                candidate.mkdir(mode=0o700)
-            except FileExistsError:
+            if candidate.exists() or candidate.is_symlink():
                 continue
             secure_directory(candidate)
             return str(candidate)
@@ -691,13 +1056,16 @@ def _require_single_link_private_staging(
 def _create_private_staging_descriptor(path: Path) -> tuple[int, tuple[int, int]]:
     """Create a private plaintext staging inode and keep it open until promotion."""
 
-    if os.name == "nt" or not (sys.platform == "darwin" or sys.platform.startswith("linux")):
+    if os.name != "nt" and not (sys.platform == "darwin" or sys.platform.startswith("linux")):
         raise UnsafePathError("Descriptor-bound dependency output is unsupported on this platform.")
-    flags = os.O_RDWR | os.O_CREAT | os.O_EXCL
-    flags |= getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
     descriptor = -1
     try:
-        descriptor = os.open(path, flags, 0o600)
+        descriptor = create_private_file_descriptor(
+            path,
+            exclusive=True,
+            read_write=True,
+            temporary=True,
+        )
         metadata = harden_private_descriptor(
             descriptor,
             expected_type=stat.S_IFREG,
@@ -767,6 +1135,160 @@ def _verified_dependency_output_alias(
     )
 
 
+def _decrypt_cbc_to_descriptor(
+    encrypted_path: Path,
+    descriptor: int,
+    *,
+    key: bytes,
+    declared_size: int | None,
+    strip_padding: bool = True,
+    allow_size_mismatch: bool = False,
+) -> int:
+    """Decrypt one verified snapshot directly into an already-held staging descriptor."""
+
+    from Crypto.Cipher import AES
+
+    if not isinstance(key, bytes) or len(key) not in {16, 24, 32}:
+        raise _DescriptorDecryptionFailure(_SelectedFileFailureCategory.KEY_UNWRAP_FAILURE)
+    cipher = AES.new(key, AES.MODE_CBC, iv=b"\x00" * 16)
+    written = 0
+    with regular_binary_reader(encrypted_path, require_private=True) as (source, metadata):
+        if metadata.st_size <= 0 or metadata.st_size % 16:
+            raise _DescriptorDecryptionFailure(_SelectedFileFailureCategory.CIPHERTEXT_INVALID)
+        while source.tell() < metadata.st_size:
+            remaining_bytes = metadata.st_size - source.tell()
+            encrypted = source.read(min(1024 * 1024, remaining_bytes))
+            if not encrypted or len(encrypted) % 16:
+                raise _DescriptorDecryptionFailure(_SelectedFileFailureCategory.CIPHERTEXT_INVALID)
+            decrypted = cipher.decrypt(encrypted)
+            if strip_padding and source.tell() == metadata.st_size:
+                padding_size = decrypted[-1]
+                if (
+                    padding_size < 1
+                    or padding_size > 16
+                    or decrypted[-padding_size:] != bytes([padding_size]) * padding_size
+                ):
+                    raise _DescriptorDecryptionFailure(_SelectedFileFailureCategory.PADDING_FAILURE)
+                decrypted = decrypted[:-padding_size]
+            view = memoryview(decrypted)
+            while view:
+                count = os.write(descriptor, view)
+                if count <= 0:
+                    raise OSError("short decrypted staging write")
+                written += count
+                view = view[count:]
+    if declared_size is not None and written != declared_size and not allow_size_mismatch:
+        raise _DescriptorDecryptionFailure(_SelectedFileFailureCategory.SIZE_MISMATCH)
+    return written
+
+
+def _close_repository_manifest(backup: Any) -> None:
+    connection = getattr(backup, "_temp_manifest_db_conn", None)
+    if connection is not None:
+        _quiet_dependency_call(connection.close)
+        backup._temp_manifest_db_conn = None
+    manifest_lock = getattr(backup, "_tvtime_manifest_lock", None)
+    if manifest_lock is not None:
+        manifest_lock.__exit__(None, None, None)
+        backup._tvtime_manifest_lock = None
+
+
+def _prepare_repository_owned_manifest(
+    backup: Any,
+    *,
+    encrypted_manifest: Path,
+    temp_root: Path,
+) -> None:
+    """Decrypt and bind Manifest.db without using the dependency's path-only writer."""
+
+    unlock = getattr(backup, "_read_and_unlock_keybag", None)
+    if not callable(unlock):
+        raise TVTimeError(DEPENDENCY_FAILURE_MESSAGE)
+    _quiet_dependency_call(unlock)
+    manifest = getattr(backup, "_manifest_plist", None)
+    keybag = getattr(backup, "_keybag", None)
+    manifest_key_value = manifest.get("ManifestKey") if isinstance(manifest, dict) else None
+    if not isinstance(manifest_key_value, bytes) or len(manifest_key_value) <= 4 or keybag is None:
+        raise TVTimeError(DEPENDENCY_FAILURE_MESSAGE)
+    manifest_class = struct.unpack("<l", manifest_key_value[:4])[0]
+    key = _quiet_dependency_call(
+        keybag.unwrapKeyForClass,
+        manifest_class,
+        manifest_key_value[4:],
+    )
+    if not isinstance(key, bytes):
+        raise TVTimeError(DEPENDENCY_FAILURE_MESSAGE)
+
+    manifest_path = Path(str(getattr(backup, "_temp_decrypted_manifest_db_path", "")))
+    manifest_absolute = no_link_absolute_path(manifest_path)
+    try:
+        manifest_absolute.relative_to(no_link_absolute_path(temp_root))
+    except ValueError as exc:
+        raise UnsafePathError(
+            "The decrypted manifest staging path escaped the private recovery root."
+        ) from exc
+    descriptor = -1
+    manifest_lock = None
+    try:
+        descriptor, identity = _create_private_staging_descriptor(manifest_path)
+        encrypted_state = _source_payload_state(encrypted_manifest)
+        _decrypt_cbc_to_descriptor(
+            encrypted_manifest,
+            descriptor,
+            key=key,
+            declared_size=encrypted_state.size,
+            strip_padding=False,
+        )
+        _harden_private_staging_descriptor(
+            manifest_path,
+            descriptor,
+            expected_identity=identity,
+        )
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+
+        manifest_lock = regular_binary_reader(manifest_path, require_private=True)
+        manifest_lock.__enter__()
+        uri = f"{manifest_absolute.as_uri()}?mode=ro&immutable=1"
+        connection = sqlite3.connect(uri, uri=True)
+        cursor = connection.cursor()
+        try:
+            cursor.execute("SELECT count(*) FROM Files;")
+            row = cursor.fetchone()
+        finally:
+            cursor.close()
+        if not row or not isinstance(row[0], int) or row[0] <= 0:
+            connection.close()
+            raise TVTimeError(DEPENDENCY_FAILURE_MESSAGE)
+        backup._temp_manifest_db_conn = connection
+        backup._tvtime_manifest_lock = manifest_lock
+        manifest_lock = None
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if manifest_lock is not None:
+            manifest_lock.__exit__(None, None, None)
+
+
+def _copy_private_file_to_descriptor(source: Path, descriptor: int) -> None:
+    with regular_binary_reader(source, require_private=True) as (handle, metadata):
+        copied = 0
+        while True:
+            chunk = handle.read(1024 * 1024)
+            if not chunk:
+                break
+            view = memoryview(chunk)
+            while view:
+                count = os.write(descriptor, view)
+                if count <= 0:
+                    raise OSError("short private staging write")
+                copied += count
+                view = view[count:]
+        if copied != metadata.st_size:
+            raise UnsafePathError("A private dependency file changed while it was copied.")
+
+
 def _harden_private_staging_descriptor(
     path: Path,
     descriptor: int,
@@ -808,13 +1330,18 @@ def _sha256_staging_descriptor(
         expected_identity=expected_identity,
     )
     digest = hashlib.sha256()
+    original_offset = os.lseek(descriptor, 0, os.SEEK_CUR)
     offset = 0
-    while True:
-        chunk = os.pread(descriptor, 1024 * 1024, offset)
-        if not chunk:
-            break
-        digest.update(chunk)
-        offset += len(chunk)
+    try:
+        os.lseek(descriptor, 0, os.SEEK_SET)
+        while True:
+            chunk = os.read(descriptor, 1024 * 1024)
+            if not chunk:
+                break
+            digest.update(chunk)
+            offset += len(chunk)
+    finally:
+        os.lseek(descriptor, original_offset, os.SEEK_SET)
     after = _require_single_link_private_staging(
         path,
         descriptor,
@@ -986,47 +1513,69 @@ def _extract_one_file(
     expected_source_state: BackupFileSnapshot | None,
     source_root_descriptor: int,
 ) -> dict[str, Any]:
-    if not isinstance(file_id_value, str):
-        raise ValueError("A selected backup file had an invalid file identifier type")
-    if not isinstance(domain_value, str):
-        raise ValueError("A selected backup file had an invalid domain type")
-    if not isinstance(relative_path_value, str):
-        raise ValueError("A selected backup file had an invalid relative path type")
-    file_id = validate_file_id(file_id_value)
-    domain = safe_domain_component(domain_value)
-    relative_path = relative_path_value
-    relative = safe_manifest_relative_path(relative_path)
-    domain_root = secure_directory(safe_join(layout.raw_root, domain))
-    target = safe_join(domain_root, relative)
-    secure_directory(target.parent)
-    if target.exists() or target.is_symlink():
-        raise ValueError(f"Refusing to overwrite extracted file: {relative_path}")
-
-    staging = safe_join(layout.temp_root, f"{file_id}.partial")
-    if staging.exists() or staging.is_symlink():
-        raise ValueError(f"Refusing to overwrite quarantined partial file: {file_id}")
-
-    file_plist = file_plist_factory(file_bplist)
-    declared_size = file_plist.filesize
-    if not isinstance(declared_size, int) or isinstance(declared_size, bool):
-        raise ValueError("A selected backup file had an invalid declared size type")
-    if declared_size < 0:
-        raise ValueError("A selected backup file had an invalid negative declared size")
+    phase = _SelectedFilePhase.MANIFEST_METADATA
+    failure_category: _SelectedFileFailureCategory | None = None
     encrypted_snapshot: Path | None = None
     staging_descriptor = -1
     staging_identity: tuple[int, int] | None = None
     try:
+        if not isinstance(file_id_value, str):
+            raise ValueError("A selected backup file had an invalid file identifier type")
+        if not isinstance(domain_value, str):
+            raise ValueError("A selected backup file had an invalid domain type")
+        if not isinstance(relative_path_value, str):
+            raise ValueError("A selected backup file had an invalid relative path type")
+        file_id = validate_file_id(file_id_value)
+        domain = safe_domain_component(domain_value)
+        relative_path = relative_path_value
+        relative_path_unsafe = False
+        try:
+            relative = safe_manifest_relative_path(relative_path)
+        except Exception:
+            relative = Path()
+            relative_path_unsafe = True
+        if relative_path_unsafe:
+            raise _SelectedFileCopyFailure(_SelectedFileFailureCategory.UNSAFE_PATH)
+        domain_root = secure_directory(safe_join(layout.raw_root, domain))
+        target = safe_join(domain_root, relative)
+        secure_directory(target.parent)
+        if target.exists() or target.is_symlink():
+            raise UnsafePathError("A selected extraction target already existed.")
+
+        staging = safe_join(layout.temp_root, f"{file_id}.partial")
+        if staging.exists() or staging.is_symlink():
+            raise UnsafePathError("A private decryption staging path already existed.")
+
+        file_plist = _quiet_dependency_call(file_plist_factory, file_bplist)
+        declared_size = file_plist.filesize
+        if not isinstance(declared_size, int) or isinstance(declared_size, bool):
+            raise ValueError("A selected backup file had an invalid declared size type")
+        if declared_size < 0:
+            raise ValueError("A selected backup file had an invalid negative declared size")
         if declared_size == 0:
+            phase = _SelectedFilePhase.STAGING
             staging_descriptor, staging_identity = _create_private_staging_descriptor(staging)
         else:
+            phase = _SelectedFilePhase.SOURCE
             if source_path is None or expected_source_state is None:
-                raise ValueError("A non-empty selected backup file had no verified source payload")
+                raise _SelectedFileCopyFailure(_SelectedFileFailureCategory.SOURCE_UNAVAILABLE)
             if file_plist.encryption_key is None:
-                raise ValueError("A non-empty encrypted file had no wrapped encryption key")
-            key = backup._keybag.unwrapKeyForClass(
-                file_plist.protection_class,
-                file_plist.encryption_key,
-            )
+                raise _SelectedFileCopyFailure(_SelectedFileFailureCategory.MISSING_ENCRYPTION_KEY)
+            phase = _SelectedFilePhase.KEY_UNWRAP
+            key_unwrap_failed = False
+            try:
+                key = _quiet_dependency_call(
+                    backup._keybag.unwrapKeyForClass,
+                    file_plist.protection_class,
+                    file_plist.encryption_key,
+                )
+            except Exception:
+                key = None
+                key_unwrap_failed = True
+            if key_unwrap_failed or not isinstance(key, bytes) or len(key) not in {16, 24, 32}:
+                raise _SelectedFileCopyFailure(_SelectedFileFailureCategory.KEY_UNWRAP_FAILURE)
+
+            phase = _SelectedFilePhase.SOURCE
             snapshot_root = secure_directory(safe_join(layout.temp_root, "encrypted-source"))
             encrypted_snapshot = safe_join(snapshot_root, file_id[:2], file_id)
             copied_state = _source_payload_state(
@@ -1046,41 +1595,29 @@ def _extract_one_file(
                     "incomplete output and retry from a completed, disconnected backup."
                 )
 
-            # The pinned dependency accepts only a path. Keep the exact private
-            # staging inode open and expose only a kernel descriptor alias, never
-            # its replaceable visible pathname.
+            phase = _SelectedFilePhase.STAGING
             staging_descriptor, staging_identity = _create_private_staging_descriptor(staging)
-            dependency_output = _verified_dependency_output_alias(
-                staging,
-                staging_descriptor,
-                expected_identity=staging_identity,
-            )
-
-            missing = object()
-            previous_backup_directory = getattr(backup, "_backup_directory", missing)
-            backup._backup_directory = str(snapshot_root)
-            # The pinned dependency prints absolute output paths in size warnings.
-            # Capture that output because this function independently records the
-            # declared and actual sizes in the private inventory.
+            phase = _SelectedFilePhase.DECRYPTION
+            decryption_failure: _SelectedFileFailureCategory | None = None
             try:
-                with redirect_stdout(io.StringIO()):
-                    backup._decrypt_file_to_disk(
-                        file_id=file_id,
-                        key=key,
-                        file_plist=file_plist,
-                        output_filepath=dependency_output,
-                    )
-            finally:
-                if previous_backup_directory is missing:
-                    with suppress(AttributeError):
-                        del backup._backup_directory
-                else:
-                    backup._backup_directory = previous_backup_directory
+                _decrypt_cbc_to_descriptor(
+                    encrypted_snapshot,
+                    staging_descriptor,
+                    key=key,
+                    declared_size=declared_size,
+                    allow_size_mismatch=True,
+                )
+            except _DescriptorDecryptionFailure as exc:
+                decryption_failure = exc.category
+            if decryption_failure is not None:
+                raise _SelectedFileCopyFailure(decryption_failure)
+            phase = _SelectedFilePhase.SOURCE
             if not _source_payload_state(encrypted_snapshot).same_content(snapshot_state):
                 raise SourceChangedError(
                     "A selected encrypted source snapshot changed during decryption. Preserve the "
                     "incomplete output and retry from a completed, disconnected backup."
                 )
+        phase = _SelectedFilePhase.STAGING
         if staging_descriptor < 0 or staging_identity is None:
             raise UnsafePathError("A private decryption staging descriptor was unavailable.")
         _harden_private_staging_descriptor(
@@ -1105,7 +1642,9 @@ def _extract_one_file(
             "mtime": _iso_mtime(file_plist.mtime),
             "sha256": staging_sha256,
         }
-        promote_file_no_replace_atomic(
+        phase = _SelectedFilePhase.PROMOTION
+        promote_open_file_no_replace_atomic(
+            staging_descriptor,
             staging,
             target,
             expected_identity=staging_identity,
@@ -1117,18 +1656,45 @@ def _extract_one_file(
             expected_identity=staging_identity,
         )
         return inventory_row
+    except _SelectedFileCopyFailure as exc:
+        failure_category = exc.category
+    except SourceChangedError:
+        failure_category = _SelectedFileFailureCategory.SOURCE_CHANGED
+    except UnsafePathError:
+        failure_category = _SelectedFileFailureCategory.UNSAFE_PATH
+    except OSError as exc:
+        if is_insufficient_space_error(exc):
+            raise
+        failure_category = _phase_failure_category(phase)
     except Exception:
-        # A dependency can leave a truncated file after ENOSPC or another
-        # mid-copy failure. Preserve it only beneath the private .tmp directory;
-        # never risk unlinking a concurrently substituted pathname and never
-        # promote it into the recovered raw tree.
-        raise
+        failure_category = _phase_failure_category(phase)
     finally:
         if staging_descriptor >= 0:
             os.close(staging_descriptor)
         if encrypted_snapshot is not None:
             with suppress(OSError):
                 encrypted_snapshot.unlink()
+    if failure_category is None:
+        failure_category = _SelectedFileFailureCategory.UNRECOGNIZED_FAILURE
+    raise _SelectedFileCopyFailure(failure_category)
+
+
+def _selected_file_failure_record(
+    *,
+    file_id: str,
+    domain: str,
+    relative_path: str,
+    category: _SelectedFileFailureCategory,
+) -> dict[str, str]:
+    """Build the bounded private row without retaining an originating exception."""
+
+    return {
+        "file_id": file_id,
+        "domain": domain,
+        "relative_path": relative_path,
+        "error": DEPENDENCY_FILE_FAILURE_MESSAGE,
+        "category": category.value,
+    }
 
 
 def _extract_backup(
@@ -1231,6 +1797,11 @@ def _extract_backup(
         except Exception as exc:
             raise TVTimeError(DEPENDENCY_FAILURE_MESSAGE) from exc
         try:
+            _prepare_repository_owned_manifest(
+                backup,
+                encrypted_manifest=dependency_source_root / "Manifest.db",
+                temp_root=layout.temp_root,
+            )
             _quiet_dependency_call(backup.test_decryption)
         except ValueError as exc:
             if str(exc) == "Failed to decrypt keys: incorrect passphrase?":
@@ -1245,6 +1816,7 @@ def _extract_backup(
         domains = _quiet_dependency_call(_query_domains, backup)
         rows = _quiet_dependency_call(_query_files, backup, domains)
         selected_declared_bytes = 0
+        selected_output_upper_bound_bytes = 0
         selected_source_states: dict[str, BackupFileSnapshot] = {}
         selected_source_paths: dict[str, Path] = {}
         for file_id_value, domain_value, relative_path_value, file_bplist in rows:
@@ -1285,20 +1857,22 @@ def _extract_backup(
                     "completed backup and try a newer extractor release."
                 )
             selected_declared_bytes += declared_size
-            if declared_size and file_id not in selected_source_states:
-                try:
-                    source_path = Path(file_id[:2], file_id)
-                except ValueError as exc:
-                    raise UnsafePathError(
-                        "A selected encrypted source payload had an unsafe path."
-                    ) from exc
-                selected_source_paths[file_id] = source_path
-                selected_source_states[file_id] = _source_payload_state(
-                    source_path,
-                    source_root_descriptor=source_root_descriptor,
-                )
+            if declared_size:
+                if file_id not in selected_source_states:
+                    try:
+                        source_path = Path(file_id[:2], file_id)
+                    except ValueError as exc:
+                        raise UnsafePathError(
+                            "A selected encrypted source payload had an unsafe path."
+                        ) from exc
+                    selected_source_paths[file_id] = source_path
+                    selected_source_states[file_id] = _source_payload_state(
+                        source_path,
+                        source_root_descriptor=source_root_descriptor,
+                    )
+                selected_output_upper_bound_bytes += selected_source_states[file_id].size
         free_bytes = shutil.disk_usage(layout.output_root).free
-        required_headroom = max(64 * 1024 * 1024, selected_declared_bytes // 10)
+        required_headroom = max(64 * 1024 * 1024, selected_output_upper_bound_bytes // 10)
         largest_encrypted_snapshot = max(
             (state.size for state in selected_source_states.values()),
             default=0,
@@ -1307,7 +1881,7 @@ def _extract_backup(
             source_manifest_snapshot.manifest_database.size if include_decrypted_manifest else 0
         )
         if free_bytes < (
-            selected_declared_bytes
+            selected_output_upper_bound_bytes
             + retained_manifest_bytes
             + largest_encrypted_snapshot
             + required_headroom
@@ -1323,14 +1897,14 @@ def _extract_backup(
                 manifest_descriptor, staged_manifest_identity = _create_private_staging_descriptor(
                     staged_manifest
                 )
-                dependency_manifest_output = _verified_dependency_output_alias(
-                    staged_manifest,
-                    manifest_descriptor,
-                    expected_identity=staged_manifest_identity,
+                _close_repository_manifest(backup)
+                dependency_manifest_path = no_link_absolute_path(
+                    Path(str(getattr(backup, "_temp_decrypted_manifest_db_path", "")))
                 )
-                _quiet_dependency_call(
-                    backup.save_manifest_file,
-                    dependency_manifest_output,
+                dependency_manifest_path.relative_to(no_link_absolute_path(layout.temp_root))
+                _copy_private_file_to_descriptor(
+                    dependency_manifest_path,
+                    manifest_descriptor,
                 )
                 _harden_private_staging_descriptor(
                     staged_manifest,
@@ -1343,7 +1917,8 @@ def _extract_backup(
                     manifest_descriptor,
                     expected_identity=staged_manifest_identity,
                 )
-                promote_file_no_replace_atomic(
+                promote_open_file_no_replace_atomic(
+                    manifest_descriptor,
                     staged_manifest,
                     decrypted_manifest,
                     expected_identity=staged_manifest_identity,
@@ -1363,7 +1938,7 @@ def _extract_backup(
 
         remaining_free_bytes = shutil.disk_usage(layout.output_root).free
         if remaining_free_bytes < (
-            selected_declared_bytes + largest_encrypted_snapshot + required_headroom
+            selected_output_upper_bound_bytes + largest_encrypted_snapshot + required_headroom
         ):
             raise insufficient_space_error()
 
@@ -1387,25 +1962,34 @@ def _extract_backup(
                         source_root_descriptor=source_root_descriptor,
                     )
                 )
+            except _SelectedFileCopyFailure as exc:
+                failures.append(
+                    _selected_file_failure_record(
+                        file_id=file_id,
+                        domain=domain,
+                        relative_path=relative_path,
+                        category=exc.category,
+                    )
+                )
             except OSError as exc:
                 if is_insufficient_space_error(exc):
                     raise insufficient_space_error() from exc
                 failures.append(
-                    {
-                        "file_id": str(file_id),
-                        "domain": str(domain),
-                        "relative_path": str(relative_path),
-                        "error": DEPENDENCY_FILE_FAILURE_MESSAGE,
-                    }
+                    _selected_file_failure_record(
+                        file_id=file_id,
+                        domain=domain,
+                        relative_path=relative_path,
+                        category=_SelectedFileFailureCategory.UNRECOGNIZED_FAILURE,
+                    )
                 )
             except Exception:  # keep a complete private failure inventory
                 failures.append(
-                    {
-                        "file_id": str(file_id),
-                        "domain": str(domain),
-                        "relative_path": str(relative_path),
-                        "error": DEPENDENCY_FILE_FAILURE_MESSAGE,
-                    }
+                    _selected_file_failure_record(
+                        file_id=file_id,
+                        domain=domain,
+                        relative_path=relative_path,
+                        category=_SelectedFileFailureCategory.UNRECOGNIZED_FAILURE,
+                    )
                 )
             if progress_callback is not None:
                 progress_callback(index, len(rows))

--- a/tvtime_extractor/protocol.py
+++ b/tvtime_extractor/protocol.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ctypes
 import json
 import os
 import select
@@ -7,6 +8,7 @@ import struct
 import threading
 import time
 from collections.abc import Callable, Mapping
+from ctypes import wintypes
 from dataclasses import dataclass
 from typing import Any, BinaryIO, TextIO
 
@@ -44,6 +46,49 @@ class ControlRequest:
     payload: dict[str, object]
 
 
+def _windows_stream_is_readable(stream: BinaryIO, wait_seconds: float) -> bool:
+    """Poll an anonymous/named pipe without using WinSock-only ``select``."""
+
+    try:
+        import msvcrt
+
+        handle = int(msvcrt.get_osfhandle(stream.fileno()))
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        get_file_type = kernel32.GetFileType
+        get_file_type.argtypes = [wintypes.HANDLE]
+        get_file_type.restype = wintypes.DWORD
+        if int(get_file_type(wintypes.HANDLE(handle))) != 3:
+            return True
+        available = wintypes.DWORD()
+        peek = kernel32.PeekNamedPipe
+        peek.argtypes = [
+            wintypes.HANDLE,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+            ctypes.POINTER(wintypes.DWORD),
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        peek.restype = wintypes.BOOL
+        if peek(
+            wintypes.HANDLE(handle),
+            None,
+            0,
+            None,
+            ctypes.byref(available),
+            None,
+        ):
+            if available.value:
+                return True
+            time.sleep(min(wait_seconds, 0.01))
+            return False
+        if int(ctypes.get_last_error() or 0) in {109, 232, 233}:
+            return True
+    except (AttributeError, ImportError, OSError, TypeError, ValueError):
+        pass
+    raise ProtocolError("The helper could not monitor its local control pipe.")
+
+
 def _read_exact(
     stream: BinaryIO,
     length: int,
@@ -62,12 +107,16 @@ def _read_exact(
             wait_seconds = min(wait_seconds, max(0.0, deadline - time.monotonic()))
             if wait_seconds == 0.0:
                 raise ProtocolError("The helper timed out waiting for a complete local frame.")
-        try:
-            readable, _, _ = select.select([stream.fileno()], [], [], wait_seconds)
-        except (OSError, ValueError) as exc:
-            raise ProtocolError("The helper could not monitor its local control pipe.") from exc
-        if not readable:
-            continue
+        if os.name == "nt":
+            if not _windows_stream_is_readable(stream, wait_seconds):
+                continue
+        else:
+            try:
+                readable, _, _ = select.select([stream.fileno()], [], [], wait_seconds)
+            except (OSError, ValueError) as exc:
+                raise ProtocolError("The helper could not monitor its local control pipe.") from exc
+            if not readable:
+                continue
         try:
             chunk = os.read(stream.fileno(), remaining)
         except OSError as exc:

--- a/tvtime_extractor/refract.py
+++ b/tvtime_extractor/refract.py
@@ -1,0 +1,665 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+import secrets
+import stat
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .errors import (
+    OutputExistsError,
+    TVTimeError,
+    UserInputError,
+    insufficient_space_error,
+    is_insufficient_space_error,
+)
+from .safety import (
+    anchored_bound_output_root,
+    anchored_existing_extraction_root,
+    create_private_file_descriptor,
+    harden_private_descriptor,
+    held_destination_parent,
+    is_within,
+    nearest_git_root,
+    no_link_absolute_path,
+    promote_open_file_no_replace_atomic,
+    read_json_regular,
+    read_regular_bytes,
+    require_private_local_destination,
+)
+
+MAXIMUM_ANALYSIS_CSV_BYTES = 64 * 1024 * 1024
+MAXIMUM_ANALYSIS_CSV_ROWS = 100_000
+MAXIMUM_ANALYSIS_CSV_CELL_BYTES = 8 * 1024 * 1024
+MAXIMUM_ANALYSIS_CSV_ROW_BYTES = 16 * 1024 * 1024
+MAXIMUM_CSV_ESCAPE_ENTRIES = 100_000
+MAXIMUM_ANALYSIS_SUMMARY_BYTES = 16 * 1024 * 1024
+
+SERIES_FIELDS = (
+    "uuid",
+    "series_id",
+    "name",
+    "country",
+    "is_ended",
+    "followed_at",
+    "last_watch_date",
+    "filters",
+    "created_at",
+    "updated_at",
+)
+EPISODE_FIELDS = (
+    "source_id",
+    "episode_id",
+    "show_id",
+    "show_name",
+    "season",
+    "episode",
+    "episode_name",
+    "air_date",
+    "seen",
+    "seen_date",
+    "is_watched",
+    "runtime",
+)
+FAVORITE_FIELDS = (
+    "uuid",
+    "id",
+    "name",
+    "type",
+    "status",
+    "created_at",
+    "watched_episode_count",
+    "aired_episode_count",
+    "is_followed",
+    "is_up_to_date",
+)
+
+_SERIES_FILENAME = "series_library.csv"
+_EPISODE_FILENAME = "episode_cache_unique.csv"
+_FAVORITE_FILENAME = "favorite_shows.csv"
+_SUMMARY_FILENAME = "analysis_summary.json"
+_TRUE_VALUES = frozenset({"1", "true", "yes", "y"})
+
+
+class RefractConversionError(UserInputError):
+    """A content-free failure while converting private analysis tables."""
+
+
+@dataclass(frozen=True)
+class RefractConversionStats:
+    series: int
+    episodes: int
+    unmatched_episode_rows: int
+    ignored_episode_rows: int
+    unmatched_favorite_rows: int
+
+
+@dataclass(frozen=True)
+class RefractConversionResult:
+    output_file: Path
+    stats: RefractConversionStats
+
+
+def _optional_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    return value if value else None
+
+
+def _positive_integer(value: object) -> int | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text or not text.isdecimal():
+        return None
+    result = int(text, 10)
+    return result if result > 0 else None
+
+
+def _nonnegative_integer(value: object) -> int | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text or not text.isdecimal():
+        return None
+    return int(text, 10)
+
+
+def _boolean(value: object) -> bool:
+    return isinstance(value, str) and value.strip().casefold() in _TRUE_VALUES
+
+
+def _normalized_watch_date(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if len(text) < 19:
+        return None
+    candidate = text[:-1] + "+00:00" if text.endswith(("Z", "z")) else text
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return parsed.replace(microsecond=0).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _file_exists(path: Path) -> bool:
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        raise RefractConversionError(
+            "A private Refract conversion input could not be inspected safely."
+        ) from exc
+    return True
+
+
+def _validated_escape_metadata(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        raise RefractConversionError(
+            "The private analysis summary had unsupported CSV escape metadata."
+        )
+    entries = 0
+    for filename, items in value.items():
+        if (
+            not isinstance(filename, str)
+            or not filename
+            or len(filename.encode("utf-8")) > 1_024
+            or not isinstance(items, list)
+        ):
+            raise RefractConversionError(
+                "The private analysis summary had unsupported CSV escape metadata."
+            )
+        entries += len(items)
+        if entries > MAXIMUM_CSV_ESCAPE_ENTRIES:
+            raise RefractConversionError(
+                "The private analysis summary had unsupported CSV escape metadata."
+            )
+        for item in items:
+            if not isinstance(item, dict) or set(item) != {"row", "field"}:
+                raise RefractConversionError(
+                    "The private analysis summary had unsupported CSV escape metadata."
+                )
+            row_number = item.get("row")
+            field = item.get("field")
+            if (
+                not isinstance(row_number, int)
+                or isinstance(row_number, bool)
+                or row_number < 1
+                or row_number > MAXIMUM_ANALYSIS_CSV_ROWS
+                or not isinstance(field, str)
+                or not field
+                or len(field.encode("utf-8")) > 1_024
+            ):
+                raise RefractConversionError(
+                    "The private analysis summary had unsupported CSV escape metadata."
+                )
+    return value
+
+
+def _escape_metadata(analysis: Path) -> dict[str, object]:
+    try:
+        summary = read_json_regular(
+            analysis / _SUMMARY_FILENAME,
+            maximum_bytes=MAXIMUM_ANALYSIS_SUMMARY_BYTES,
+            require_private=True,
+        )
+    except (TVTimeError, OSError, UnicodeError, ValueError, json.JSONDecodeError) as exc:
+        raise RefractConversionError(
+            "The private analysis summary was unavailable or had unsupported JSON."
+        ) from exc
+    if not isinstance(summary, dict):
+        raise RefractConversionError("The private analysis summary had an unsupported format.")
+    return _validated_escape_metadata(summary.get("csv_spreadsheet_escaped_cells"))
+
+
+def _read_csv(
+    path: Path,
+    fields: tuple[str, ...],
+    escaped_cells: object,
+) -> list[dict[str, str]]:
+    if not isinstance(escaped_cells, list):
+        raise RefractConversionError(
+            "The private analysis summary had unsupported CSV escape metadata."
+        )
+    try:
+        payload = read_regular_bytes(
+            path,
+            maximum_bytes=MAXIMUM_ANALYSIS_CSV_BYTES,
+            require_private=True,
+        )
+        text = payload.decode("utf-8")
+    except (TVTimeError, OSError, UnicodeError) as exc:
+        raise RefractConversionError(
+            "A private Refract conversion table could not be read safely."
+        ) from exc
+    try:
+        if any(
+            len(line.encode("utf-8")) > MAXIMUM_ANALYSIS_CSV_ROW_BYTES
+            for line in text.splitlines(keepends=True)
+        ):
+            raise RefractConversionError(
+                "A private Refract conversion table exceeded its safe row limit."
+            )
+    except UnicodeError as exc:
+        raise RefractConversionError(
+            "A private Refract conversion table contained invalid Unicode text."
+        ) from exc
+
+    rows: list[dict[str, str]] = []
+    previous_field_limit = csv.field_size_limit()
+    try:
+        csv.field_size_limit(MAXIMUM_ANALYSIS_CSV_CELL_BYTES + 1)
+        reader = csv.DictReader(io.StringIO(text, newline=""))
+        if tuple(reader.fieldnames or ()) != fields:
+            raise RefractConversionError(
+                "A private Refract conversion table had an unsupported header."
+            )
+        for row in reader:
+            if len(rows) >= MAXIMUM_ANALYSIS_CSV_ROWS:
+                raise RefractConversionError(
+                    "A private Refract conversion table exceeded its safe row limit."
+                )
+            if None in row or any(value is None for value in row.values()):
+                raise RefractConversionError(
+                    "A private Refract conversion table had an unsupported row shape."
+                )
+            converted = {field: str(row[field]) for field in fields}
+            cell_sizes = [len(value.encode("utf-8")) for value in converted.values()]
+            if (
+                any(size > MAXIMUM_ANALYSIS_CSV_CELL_BYTES + 1 for size in cell_sizes)
+                or sum(cell_sizes) > MAXIMUM_ANALYSIS_CSV_ROW_BYTES
+            ):
+                raise RefractConversionError(
+                    "A private Refract conversion table exceeded its safe cell limit."
+                )
+            rows.append(converted)
+    except csv.Error as exc:
+        raise RefractConversionError(
+            "A private Refract conversion table had unsupported CSV data."
+        ) from exc
+    finally:
+        csv.field_size_limit(previous_field_limit)
+
+    seen: set[tuple[int, str]] = set()
+    for item in escaped_cells:
+        assert isinstance(item, dict)
+        row_number = item["row"]
+        field = item["field"]
+        assert isinstance(row_number, int)
+        assert isinstance(field, str)
+        coordinate = (row_number, field)
+        if coordinate in seen or row_number > len(rows) or field not in rows[row_number - 1]:
+            raise RefractConversionError("The private CSV escape metadata did not match its table.")
+        value = rows[row_number - 1][field]
+        if (
+            not value.startswith("'")
+            or len(value) < 2
+            or not value[1:].startswith(("=", "+", "-", "@", "\t", "\r"))
+        ):
+            raise RefractConversionError("The private CSV escape metadata did not match its table.")
+        rows[row_number - 1][field] = value[1:]
+        seen.add(coordinate)
+    return rows
+
+
+def _read_table(
+    analysis: Path,
+    filename: str,
+    fields: tuple[str, ...],
+    escape_metadata: dict[str, object],
+    *,
+    required: bool,
+) -> list[dict[str, str]]:
+    path = analysis / filename
+    if not _file_exists(path):
+        if required:
+            raise RefractConversionError("A required private Refract conversion table was absent.")
+        return []
+    return _read_csv(path, fields, escape_metadata.get(filename, []))
+
+
+def _episode_from_row(row: dict[str, str]) -> tuple[int, int, dict[str, Any]] | None:
+    episode_id = _positive_integer(row.get("episode_id"))
+    season_number = _nonnegative_integer(row.get("season"))
+    episode_number = _nonnegative_integer(row.get("episode"))
+    name = _optional_text(row.get("episode_name"))
+    if (
+        episode_id is None
+        or season_number is None
+        or episode_number is None
+        or (name is not None and name.strip().upper() == "TBA")
+    ):
+        return None
+    watched_at = _normalized_watch_date(row.get("seen_date"))
+    watched = _boolean(row.get("seen")) or _boolean(row.get("is_watched")) or bool(watched_at)
+    episode = {
+        "id": {"tvdb": episode_id, "imdb": None},
+        "number": episode_number,
+        "name": name,
+        "special": season_number == 0,
+        "is_watched": watched,
+        "watched_at": watched_at,
+        "rewatch_count": 0,
+        "watched_count": 1 if watched else 0,
+    }
+    return season_number, episode_number, episode
+
+
+def _group_episodes(
+    rows: list[dict[str, str]],
+    series_ids: set[int],
+) -> tuple[dict[int, list[dict[str, Any]]], int, int]:
+    positioned: dict[int, dict[tuple[int, int], dict[str, Any] | None]] = defaultdict(dict)
+    unmatched = 0
+    ignored = 0
+    for row in rows:
+        show_id = _positive_integer(row.get("show_id"))
+        if show_id is None or show_id not in series_ids:
+            unmatched += 1
+            continue
+        converted = _episode_from_row(row)
+        if converted is None:
+            ignored += 1
+            continue
+        season_number, episode_number, episode = converted
+        position = (season_number, episode_number)
+        previous = positioned[show_id].get(position)
+        if previous is None and position in positioned[show_id]:
+            ignored += 1
+            continue
+        if previous is not None:
+            previous_id = previous["id"]["tvdb"]
+            current_id = episode["id"]["tvdb"]
+            if previous_id != current_id:
+                positioned[show_id][position] = None
+                ignored += 2
+                continue
+            previous_rank = (bool(previous["is_watched"]), previous["watched_at"] or "")
+            current_rank = (bool(episode["is_watched"]), episode["watched_at"] or "")
+            if current_rank >= previous_rank:
+                positioned[show_id][position] = episode
+            ignored += 1
+            continue
+        positioned[show_id][position] = episode
+
+    grouped: dict[int, list[dict[str, Any]]] = {}
+    for show_id, by_position in positioned.items():
+        seasons: dict[int, list[dict[str, Any]]] = defaultdict(list)
+        for (season_number, _episode_number), episode in sorted(by_position.items()):
+            if episode is not None:
+                seasons[season_number].append(episode)
+        grouped[show_id] = [
+            {
+                "number": season_number,
+                "is_specials": season_number == 0,
+                "episodes": episodes,
+            }
+            for season_number, episodes in sorted(seasons.items())
+        ]
+    return grouped, unmatched, ignored
+
+
+def _favorite_ids(rows: list[dict[str, str]], series_ids: set[int]) -> tuple[set[int], int]:
+    matched: set[int] = set()
+    unmatched = 0
+    for row in rows:
+        favorite_id = _positive_integer(row.get("id"))
+        if favorite_id is None or favorite_id not in series_ids:
+            unmatched += 1
+        else:
+            matched.add(favorite_id)
+    return matched, unmatched
+
+
+def _validate_payload(payload: object) -> None:
+    if not isinstance(payload, list) or not payload:
+        raise RefractConversionError("No convertible series were present in the private table.")
+    for show in payload:
+        if not isinstance(show, dict) or set(show) != {
+            "uuid",
+            "id",
+            "created_at",
+            "title",
+            "status",
+            "is_favorite",
+            "_noEpisodeData",
+            "seasons",
+        }:
+            raise RefractConversionError("The generated Refract series data was invalid.")
+        identifier = show.get("id")
+        if (
+            not isinstance(identifier, dict)
+            or set(identifier) != {"tvdb", "imdb"}
+            or not isinstance(identifier.get("tvdb"), int)
+            or identifier.get("imdb") is not None
+            or show.get("status") != "up_to_date"
+            or not isinstance(show.get("is_favorite"), bool)
+            or not isinstance(show.get("_noEpisodeData"), bool)
+            or not isinstance(show.get("seasons"), list)
+        ):
+            raise RefractConversionError("The generated Refract series data was invalid.")
+        for season in show["seasons"]:
+            if (
+                not isinstance(season, dict)
+                or set(season) != {"number", "is_specials", "episodes"}
+                or not isinstance(season.get("number"), int)
+                or not isinstance(season.get("is_specials"), bool)
+                or not isinstance(season.get("episodes"), list)
+            ):
+                raise RefractConversionError("The generated Refract episode data was invalid.")
+            for episode in season["episodes"]:
+                if (
+                    not isinstance(episode, dict)
+                    or set(episode)
+                    != {
+                        "id",
+                        "number",
+                        "name",
+                        "special",
+                        "is_watched",
+                        "watched_at",
+                        "rewatch_count",
+                        "watched_count",
+                    }
+                    or not isinstance(episode.get("number"), int)
+                    or not isinstance(episode.get("special"), bool)
+                    or not isinstance(episode.get("is_watched"), bool)
+                    or episode.get("rewatch_count") != 0
+                    or episode.get("watched_count") not in {0, 1}
+                ):
+                    raise RefractConversionError("The generated Refract episode data was invalid.")
+
+
+def _build_payload_from_analysis(
+    analysis: Path,
+) -> tuple[list[dict[str, Any]], RefractConversionStats]:
+    metadata = _escape_metadata(analysis)
+    series_rows = _read_table(
+        analysis,
+        _SERIES_FILENAME,
+        SERIES_FIELDS,
+        metadata,
+        required=True,
+    )
+    episode_rows = _read_table(
+        analysis,
+        _EPISODE_FILENAME,
+        EPISODE_FIELDS,
+        metadata,
+        required=False,
+    )
+    favorite_rows = _read_table(
+        analysis,
+        _FAVORITE_FILENAME,
+        FAVORITE_FIELDS,
+        metadata,
+        required=False,
+    )
+
+    by_id: dict[int, dict[str, str]] = {}
+    for row in series_rows:
+        series_id = _positive_integer(row.get("series_id"))
+        if series_id is None or series_id in by_id:
+            raise RefractConversionError(
+                "The private series table contained an invalid or duplicate series ID."
+            )
+        by_id[series_id] = row
+    if not by_id:
+        raise RefractConversionError("No convertible series were present in the private table.")
+
+    series_ids = set(by_id)
+    episodes_by_show, unmatched_episodes, ignored_episodes = _group_episodes(
+        episode_rows, series_ids
+    )
+    favorites, unmatched_favorites = _favorite_ids(favorite_rows, series_ids)
+
+    payload: list[dict[str, Any]] = []
+    episode_count = 0
+    for series_id, row in by_id.items():
+        seasons = episodes_by_show.get(series_id, [])
+        episode_count += sum(len(season["episodes"]) for season in seasons)
+        payload.append(
+            {
+                "uuid": _optional_text(row.get("uuid")),
+                "id": {"tvdb": series_id, "imdb": None},
+                "created_at": _optional_text(row.get("created_at")),
+                "title": _optional_text(row.get("name")),
+                "status": "up_to_date",
+                "is_favorite": series_id in favorites,
+                "_noEpisodeData": not seasons,
+                "seasons": seasons,
+            }
+        )
+    payload.sort(key=lambda item: ((item["title"] or "").casefold(), item["id"]["tvdb"]))
+    _validate_payload(payload)
+    try:
+        encoded = json.dumps(payload, indent=2, ensure_ascii=False) + "\n"
+        if json.loads(encoded) != payload:
+            raise ValueError("JSON round-trip mismatch")
+    except (TypeError, ValueError, UnicodeError, json.JSONDecodeError) as exc:
+        raise RefractConversionError("The generated Refract JSON was invalid.") from exc
+    return payload, RefractConversionStats(
+        series=len(payload),
+        episodes=episode_count,
+        unmatched_episode_rows=unmatched_episodes,
+        ignored_episode_rows=ignored_episodes,
+        unmatched_favorite_rows=unmatched_favorites,
+    )
+
+
+def _validated_analysis_path(path: Path) -> Path:
+    analysis = no_link_absolute_path(path)
+    try:
+        metadata = analysis.lstat()
+    except OSError as exc:
+        raise RefractConversionError("The private analysis directory was unavailable.") from exc
+    if not stat.S_ISDIR(metadata.st_mode) or analysis.is_symlink():
+        raise RefractConversionError("The private analysis directory was unsafe.")
+    if nearest_git_root(analysis) is not None:
+        raise RefractConversionError(
+            "Refusing to read private recovered data from inside a Git repository."
+        )
+    return analysis
+
+
+def build_refract_series_payload(
+    analysis_directory: Path,
+) -> tuple[list[dict[str, Any]], RefractConversionStats]:
+    """Read private analysis tables and build a validated TV-Time-Out series payload."""
+
+    analysis = _validated_analysis_path(analysis_directory)
+    extraction_root = analysis.parent
+    with anchored_existing_extraction_root(extraction_root) as anchored_extraction:
+        anchored_analysis = anchored_extraction / analysis.name
+        return _build_payload_from_analysis(anchored_analysis)
+
+
+def _validated_output_path(analysis: Path, output_directory: Path) -> Path:
+    output = no_link_absolute_path(output_directory)
+    require_private_local_destination(output)
+    if output.exists() or output.is_symlink():
+        raise OutputExistsError(
+            "The Refract output directory already exists. Choose a new private directory."
+        )
+    if is_within(output, analysis) or is_within(analysis, output):
+        raise RefractConversionError("The private analysis and Refract output must not overlap.")
+    if nearest_git_root(output) is not None:
+        raise RefractConversionError(
+            "Refusing to place private Refract import data inside a Git repository."
+        )
+    return output
+
+
+def _write_payload(root: Path, filename: str, payload: list[dict[str, Any]]) -> None:
+    final_path = root / filename
+    staging_path = root / f".{filename}.{secrets.token_hex(8)}.partial"
+    encoded = (json.dumps(payload, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+    descriptor = -1
+    try:
+        descriptor = create_private_file_descriptor(staging_path, exclusive=True)
+        opened = harden_private_descriptor(
+            descriptor,
+            expected_type=stat.S_IFREG,
+            mode=0o600,
+        )
+        remaining = memoryview(encoded)
+        while remaining:
+            written = os.write(descriptor, remaining)
+            if written <= 0:
+                raise OSError("short private Refract JSON write")
+            remaining = remaining[written:]
+        os.fsync(descriptor)
+        after = os.fstat(descriptor)
+        identity = (int(after.st_dev), int(after.st_ino))
+        if identity != (int(opened.st_dev), int(opened.st_ino)):
+            raise RefractConversionError("The private Refract staging file changed unexpectedly.")
+        promote_open_file_no_replace_atomic(
+            descriptor,
+            staging_path,
+            final_path,
+            expected_identity=identity,
+            durable=True,
+        )
+    except OSError as exc:
+        if is_insufficient_space_error(exc):
+            raise insufficient_space_error() from exc
+        raise
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+
+
+def convert_refract_series(
+    *,
+    analysis_directory: Path,
+    output_directory: Path,
+    export_date: date | None = None,
+) -> RefractConversionResult:
+    """Convert recovered analysis tables into one fresh private Refract series artifact."""
+
+    analysis = _validated_analysis_path(analysis_directory)
+    output = _validated_output_path(analysis, output_directory)
+    payload, stats = build_refract_series_payload(analysis)
+    filename = f"tvtime-series-{(export_date or date.today()).isoformat()}.json"
+    with (
+        held_destination_parent(output) as (parent_handle, parent_identity, visible_output),
+        anchored_bound_output_root(
+            visible_output,
+            destination_parent_descriptor=parent_handle,
+            expected_parent_identity=parent_identity,
+        ) as anchored_output,
+    ):
+        _write_payload(anchored_output, filename, payload)
+    return RefractConversionResult(output_file=output / filename, stats=stats)

--- a/tvtime_extractor/safety.py
+++ b/tvtime_extractor/safety.py
@@ -22,6 +22,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any, BinaryIO, TextIO
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
+from . import windows_native as _windows_native
 from .errors import OutputExistsError, PartialExtractionError, UnsafePathError, UserInputError
 
 EXTRACTION_DIRECTORY_NAME = "TVTime-Extraction"
@@ -55,6 +56,12 @@ _WINDOWS_FILE_ATTRIBUTE_DIRECTORY = 0x00000010
 _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
 _WINDOWS_GENERIC_READ = 0x80000000
 _WINDOWS_FILE_READ_ATTRIBUTES = 0x00000080
+_WINDOWS_FILE_LIST_DIRECTORY = 0x00000001
+_WINDOWS_FILE_ADD_FILE = 0x00000002
+_WINDOWS_FILE_ADD_SUBDIRECTORY = 0x00000004
+_WINDOWS_FILE_TRAVERSE = 0x00000020
+_WINDOWS_FILE_WRITE_ATTRIBUTES = 0x00000100
+_WINDOWS_READ_CONTROL = 0x00020000
 _WINDOWS_FILE_SHARE_READ = 0x00000001
 _WINDOWS_FILE_SHARE_WRITE = 0x00000002
 _WINDOWS_FILE_SHARE_DELETE = 0x00000004
@@ -64,11 +71,6 @@ _WINDOWS_FILE_FLAG_BACKUP_SEMANTICS = 0x02000000
 _WINDOWS_INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
 _LINUX_RENAME_NOREPLACE = 1
 _DARWIN_RENAME_EXCL = 0x00000004
-WINDOWS_FRESH_RECOVERY_UNSUPPORTED_MESSAGE = (
-    "Fresh extraction and recovery are not supported on Windows in this release because Python "
-    "cannot atomically create and lock the new plaintext output directory. Use macOS or Linux "
-    "for extraction; Windows can safely analyze or report an existing complete extraction."
-)
 _REMOTE_FILESYSTEM_TYPES = frozenset(
     {
         "9p",
@@ -216,6 +218,7 @@ class _WindowsBoundOutputState:
     handle: int
     identity: tuple[int, int]
     visible_root: Path
+    strict_acl: bool
 
 
 _ANCHORED_OUTPUT_STATE: ContextVar[_AnchoredOutputState | None] = ContextVar(
@@ -583,10 +586,13 @@ def _running_on_windows() -> bool:
 
 
 def require_fresh_output_platform_support() -> None:
-    """Fail before creating plaintext output where fresh-root creation is not atomic."""
+    """Require a platform with atomic fresh-root creation and identity binding."""
 
     if _running_on_windows():
-        raise UserInputError(WINDOWS_FRESH_RECOVERY_UNSUPPORTED_MESSAGE)
+        try:
+            _windows_native.require_supported_runtime()
+        except _windows_native.WindowsNativeError as exc:
+            raise UserInputError(str(exc)) from exc
 
 
 def _windows_kernel32() -> Any:
@@ -619,7 +625,12 @@ def _windows_handle_value(value: object) -> int:
     return -1
 
 
-def _windows_create_file_directory_handle(path: Path) -> int:
+def _windows_create_file_directory_handle(
+    path: Path,
+    *,
+    writable: bool = False,
+    allow_delete_sharing: bool = False,
+) -> int:
     """Open one directory while deliberately denying delete/rename sharing."""
 
     kernel32 = _windows_kernel32()
@@ -636,10 +647,25 @@ def _windows_create_file_directory_handle(path: Path) -> int:
         ]
         create_file.restype = ctypes.c_void_p
     try:
+        desired_access = (
+            _WINDOWS_FILE_LIST_DIRECTORY
+            | _WINDOWS_FILE_TRAVERSE
+            | _WINDOWS_FILE_READ_ATTRIBUTES
+            | _WINDOWS_READ_CONTROL
+        )
+        if writable:
+            desired_access |= (
+                _WINDOWS_FILE_ADD_FILE
+                | _WINDOWS_FILE_ADD_SUBDIRECTORY
+                | _WINDOWS_FILE_WRITE_ATTRIBUTES
+            )
+        share_mode = _WINDOWS_FILE_SHARE_READ | _WINDOWS_FILE_SHARE_WRITE
+        if allow_delete_sharing:
+            share_mode |= _WINDOWS_FILE_SHARE_DELETE
         opened = create_file(
             os.fspath(path),
-            _WINDOWS_FILE_READ_ATTRIBUTES,
-            _WINDOWS_FILE_SHARE_READ | _WINDOWS_FILE_SHARE_WRITE,
+            desired_access,
+            share_mode,
             None,
             _WINDOWS_OPEN_EXISTING,
             _WINDOWS_FILE_FLAG_BACKUP_SEMANTICS | _WINDOWS_FILE_FLAG_OPEN_REPARSE_POINT,
@@ -683,6 +709,8 @@ def _windows_create_file_regular_handle(path: Path) -> int:
         raise UnsafePathError("A required private data file could not be opened safely.") from exc
     handle = _windows_handle_value(opened)
     if handle in {-1, 0, _WINDOWS_INVALID_HANDLE_VALUE}:
+        if int(ctypes.get_last_error() or 0) in {2, 3}:
+            raise UnsafePathError("A required private data file was unavailable.")
         raise _windows_error("A required private data file could not be opened safely.")
     return handle
 
@@ -818,8 +846,12 @@ def _windows_close_handle(handle: int) -> None:
         raise _windows_error("A Windows directory handle could not be closed safely.")
 
 
-def _windows_open_locked_directory(path: Path) -> tuple[int, tuple[int, int]]:
-    handle = _windows_create_file_directory_handle(path)
+def _windows_open_locked_directory(
+    path: Path,
+    *,
+    writable: bool = False,
+) -> tuple[int, tuple[int, int]]:
+    handle = _windows_create_file_directory_handle(path, writable=writable)
     try:
         return handle, _windows_directory_identity(handle)
     except BaseException:
@@ -838,6 +870,34 @@ def _require_windows_visible_directory_identity(
         visible_handle, visible_identity = _windows_open_locked_directory(path)
         if visible_identity != expected_identity:
             raise UnsafePathError("The visible Windows directory identity changed during recovery.")
+    finally:
+        if visible_handle > 0:
+            _windows_close_handle(visible_handle)
+
+
+def _require_windows_visible_artifact_identity(
+    path: Path,
+    *,
+    expected_identity: tuple[int, int],
+    directory: bool,
+    allow_delete_sharing: bool = False,
+) -> None:
+    visible_handle = -1
+    try:
+        if directory:
+            if allow_delete_sharing:
+                visible_handle = _windows_create_file_directory_handle(
+                    path,
+                    allow_delete_sharing=True,
+                )
+                visible_identity = _windows_directory_identity(visible_handle)
+            else:
+                visible_handle, visible_identity = _windows_open_locked_directory(path)
+        else:
+            visible_handle = _windows_create_file_regular_handle(path)
+            visible_identity = _windows_regular_file_information(visible_handle).identity
+        if visible_identity != expected_identity:
+            raise UnsafePathError("The visible Windows artifact identity changed during recovery.")
     finally:
         if visible_handle > 0:
             _windows_close_handle(visible_handle)
@@ -906,6 +966,10 @@ def require_bound_destination_parent(
         descriptor_identity = _windows_directory_identity(destination_parent_descriptor)
         if descriptor_identity != expected_identity:
             raise UnsafePathError("The destination directory handle identity did not match.")
+        try:
+            _windows_native.require_recovery_capabilities(destination_parent_descriptor)
+        except _windows_native.WindowsNativeError as exc:
+            raise UnsafePathError(str(exc)) from exc
         _require_windows_visible_directory_identity(
             parent,
             expected_identity=descriptor_identity,
@@ -966,7 +1030,7 @@ def held_destination_parent(
     handle = -1
     try:
         if _running_on_windows():
-            handle, identity = _windows_open_locked_directory(parent)
+            handle, identity = _windows_open_locked_directory(parent, writable=True)
         else:
             try:
                 handle = os.open(parent, _descriptor_flags(stat.S_IFDIR))
@@ -1012,6 +1076,31 @@ def _open_bound_fresh_output_root(
     )
     if output_root.parent != parent or output_root.name in {"", ".", ".."}:
         raise UnsafePathError("The output was not a direct child of its selected destination.")
+    if _running_on_windows():
+        try:
+            _windows_native.require_private_ntfs_volume(destination_parent_descriptor)
+            descriptor = _windows_native.create_fresh_directory(
+                destination_parent_descriptor,
+                output_root.name,
+            )
+        except _windows_native.WindowsObjectExistsError as exc:
+            raise OutputExistsError(
+                "The destination already exists. Choose a new dedicated folder so nothing is "
+                "overwritten."
+            ) from exc
+        except _windows_native.WindowsNativeError as exc:
+            raise UnsafePathError(str(exc)) from exc
+        try:
+            identity = _windows_directory_identity(descriptor)
+            _require_windows_visible_directory_identity(
+                output_root,
+                expected_identity=identity,
+            )
+            return descriptor, identity
+        except BaseException:
+            with suppress(Exception):
+                _windows_close_handle(descriptor)
+            raise
     try:
         os.mkdir(output_root.name, mode=0o700, dir_fd=destination_parent_descriptor)
     except FileExistsError as exc:
@@ -1125,6 +1214,40 @@ def _anchored_relative_temporary_directories() -> Iterator[None]:
 
 
 @contextmanager
+def _anchored_windows_temporary_directories() -> Iterator[None]:
+    """Create Windows temporary directories through the active capability root."""
+
+    original_mkdtemp = tempfile.mkdtemp
+
+    def capability_mkdtemp(
+        suffix: str | None = None,
+        prefix: str | None = None,
+        dir: str | os.PathLike[str] | None = None,
+    ) -> str:
+        configured_parent = dir if dir is not None else tempfile.tempdir
+        if not configured_parent:
+            raise UnsafePathError("A private temporary directory was not explicitly anchored.")
+        parent = no_link_absolute_path(Path(configured_parent))
+        if _windows_bound_relative_path(parent) is None:
+            raise UnsafePathError("A private temporary directory escaped its trusted output root.")
+        for _attempt in range(128):
+            candidate = safe_join(
+                parent,
+                f"{prefix or 'tmp'}{secrets.token_hex(16)}{suffix or ''}",
+            )
+            if candidate.exists() or candidate.is_symlink():
+                continue
+            return str(secure_directory(candidate))
+        raise UnsafePathError("A private temporary directory could not be allocated safely.")
+
+    tempfile.mkdtemp = capability_mkdtemp
+    try:
+        yield
+    finally:
+        tempfile.mkdtemp = original_mkdtemp
+
+
+@contextmanager
 def anchored_bound_output_root(
     output_root: Path,
     *,
@@ -1140,6 +1263,62 @@ def anchored_bound_output_root(
 
     require_fresh_output_platform_support()
     visible_root = no_link_absolute_path(output_root)
+
+    if _running_on_windows():
+        root_handle = -1
+        root_identity = (0, 0)
+        token = None
+        temporary_context = None
+        try:
+            root_handle, root_identity = _open_bound_fresh_output_root(
+                visible_root,
+                destination_parent_descriptor=destination_parent_descriptor,
+                expected_identity=expected_parent_identity,
+            )
+            token = _WINDOWS_BOUND_OUTPUT_STATE.set(
+                _WindowsBoundOutputState(
+                    handle=root_handle,
+                    identity=root_identity,
+                    visible_root=visible_root,
+                    strict_acl=True,
+                )
+            )
+            temporary_context = _anchored_windows_temporary_directories()
+            temporary_context.__enter__()
+            yield visible_root
+        finally:
+            validation_error: BaseException | None = None
+            if root_handle >= 0:
+                try:
+                    if _windows_directory_identity(root_handle) != root_identity:
+                        raise UnsafePathError(
+                            "The trusted Windows output-root handle identity changed."
+                        )
+                    _require_visible_output_identity(
+                        visible_root,
+                        destination_parent_descriptor=destination_parent_descriptor,
+                        expected_parent_identity=expected_parent_identity,
+                        expected_output_identity=root_identity,
+                    )
+                except BaseException as exc:
+                    validation_error = exc
+            if temporary_context is not None:
+                try:
+                    temporary_context.__exit__(None, None, None)
+                except BaseException as exc:
+                    if validation_error is None:
+                        validation_error = exc
+            if token is not None:
+                _WINDOWS_BOUND_OUTPUT_STATE.reset(token)
+            if root_handle >= 0:
+                try:
+                    _windows_close_handle(root_handle)
+                except BaseException as exc:
+                    if validation_error is None:
+                        validation_error = exc
+            if validation_error is not None:
+                raise validation_error
+        return
 
     saved_cwd_descriptor = -1
     root_descriptor = -1
@@ -1240,16 +1419,26 @@ def anchored_existing_extraction_root(extraction_root: Path) -> Iterator[Path]:
     if _running_on_windows():
         root_handle = -1
         token = None
+        temporary_context = None
         root_identity = (0, 0)
         try:
             root_handle, root_identity = _windows_open_locked_directory(visible_root)
+            strict_acl = False
+            try:
+                _windows_native.validate_private_acl(root_handle)
+                strict_acl = True
+            except _windows_native.WindowsNativeError:
+                pass
             token = _WINDOWS_BOUND_OUTPUT_STATE.set(
                 _WindowsBoundOutputState(
                     handle=root_handle,
                     identity=root_identity,
                     visible_root=visible_root,
+                    strict_acl=strict_acl,
                 )
             )
+            temporary_context = _anchored_windows_temporary_directories()
+            temporary_context.__enter__()
             yield visible_root
         finally:
             validation_error: BaseException | None = None
@@ -1265,6 +1454,12 @@ def anchored_existing_extraction_root(extraction_root: Path) -> Iterator[Path]:
                     )
                 except BaseException as exc:
                     validation_error = exc
+            if temporary_context is not None:
+                try:
+                    temporary_context.__exit__(None, None, None)
+                except BaseException as exc:
+                    if validation_error is None:
+                        validation_error = exc
             if token is not None:
                 _WINDOWS_BOUND_OUTPUT_STATE.reset(token)
             if root_handle >= 0:
@@ -1547,6 +1742,60 @@ def _identity(metadata: os.stat_result) -> tuple[int, int]:
     return (getattr(metadata, "st_dev", 0), getattr(metadata, "st_ino", 0))
 
 
+def _windows_bound_relative_path(path: Path) -> tuple[_WindowsBoundOutputState, Path] | None:
+    if not _running_on_windows():
+        return None
+    state = _WINDOWS_BOUND_OUTPUT_STATE.get()
+    if state is None:
+        return None
+    if _windows_directory_identity(state.handle) != state.identity:
+        raise UnsafePathError("The trusted Windows output-root handle identity changed.")
+    candidate = Path(os.path.abspath(os.fspath(path.expanduser())))
+    try:
+        relative = candidate.relative_to(state.visible_root)
+    except ValueError as exc:
+        raise UnsafePathError("A private recovery path escaped its trusted output root.") from exc
+    if any(component in {"", ".", ".."} for component in relative.parts):
+        raise UnsafePathError("A private recovery path escaped its trusted output root.")
+    return state, relative
+
+
+def create_private_file_descriptor(
+    path: Path,
+    *,
+    exclusive: bool,
+    read_write: bool = False,
+    temporary: bool = False,
+) -> int:
+    """Create/truncate one private file through the active platform capability root."""
+
+    windows_path = _windows_bound_relative_path(path)
+    if windows_path is not None:
+        state, relative = windows_path
+        if not relative.parts:
+            raise UnsafePathError("A private file path did not name an output descendant.")
+        try:
+            handle = _windows_native.create_relative_regular_file_path(
+                state.handle,
+                relative.parts,
+                temporary=temporary,
+                exclusive=exclusive,
+                require_existing_private_acl=state.strict_acl,
+            )
+            flags = (os.O_RDWR if read_write else os.O_WRONLY) | getattr(os, "O_BINARY", 0)
+            return _windows_native.handle_to_file_descriptor(handle, flags=flags)
+        except _windows_native.WindowsObjectExistsError as exc:
+            raise FileExistsError(os.fspath(path)) from exc
+        except _windows_native.WindowsNativeError as exc:
+            raise UnsafePathError(str(exc)) from exc
+
+    flags = os.O_RDWR if read_write else os.O_WRONLY
+    flags |= os.O_CREAT | (os.O_EXCL if exclusive else os.O_TRUNC)
+    flags |= getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0)
+    flags |= getattr(os, "O_NOFOLLOW", 0)
+    return os.open(path, flags, 0o600)
+
+
 def _require_expected_type(metadata: os.stat_result, expected_type: int) -> None:
     if stat.S_IFMT(metadata.st_mode) != expected_type:
         raise UnsafePathError("A private recovery artifact had an unsafe file type.")
@@ -1640,6 +1889,39 @@ def require_private_path(
         raise UnsafePathError("A private recovery artifact redirected through a link.")
     _require_expected_type(before, expected_type)
     if os.name == "nt":
+        bound = _windows_bound_relative_path(path)
+        if bound is not None:
+            state, relative = bound
+            if not relative.parts:
+                if _windows_directory_identity(state.handle) != state.identity:
+                    raise UnsafePathError("The trusted Windows output-root identity changed.")
+                if state.strict_acl:
+                    _windows_native.validate_private_acl(state.handle)
+                _require_windows_visible_directory_identity(
+                    path,
+                    expected_identity=state.identity,
+                )
+                return before
+            handle = -1
+            try:
+                handle = _windows_native.open_relative_path(
+                    state.handle,
+                    relative.parts,
+                    directory=expected_type == stat.S_IFDIR,
+                )
+                information = _windows_native.handle_information(handle)
+                if state.strict_acl:
+                    _windows_native.validate_private_acl(handle)
+                _require_windows_visible_artifact_identity(
+                    path,
+                    expected_identity=information.identity,
+                    directory=expected_type == stat.S_IFDIR,
+                )
+            except _windows_native.WindowsNativeError as exc:
+                raise UnsafePathError(str(exc)) from exc
+            finally:
+                if handle >= 0:
+                    _windows_close_handle(handle)
         return before
 
     descriptor = -1
@@ -1669,6 +1951,44 @@ def _harden_private_path(path: Path, *, expected_type: int, mode: int) -> os.sta
     if _is_link_or_reparse_point(path):
         raise UnsafePathError("Refusing to secure a symbolic link or reparse point.")
     if os.name == "nt":
+        bound = _windows_bound_relative_path(path)
+        if bound is not None:
+            state, relative = bound
+            if not relative.parts:
+                metadata = path.lstat()
+                _require_expected_type(metadata, expected_type)
+                if expected_type != stat.S_IFDIR:
+                    raise UnsafePathError("The Windows output root was not a directory.")
+                if state.strict_acl:
+                    _windows_native.validate_private_acl(state.handle)
+                _require_windows_visible_directory_identity(
+                    path,
+                    expected_identity=state.identity,
+                )
+                return metadata
+            handle = -1
+            try:
+                handle = _windows_native.open_relative_path(
+                    state.handle,
+                    relative.parts,
+                    directory=expected_type == stat.S_IFDIR,
+                )
+                information = _windows_native.handle_information(handle)
+                metadata = path.lstat()
+                _require_expected_type(metadata, expected_type)
+                if state.strict_acl:
+                    _windows_native.validate_private_acl(handle)
+                _require_windows_visible_artifact_identity(
+                    path,
+                    expected_identity=information.identity,
+                    directory=expected_type == stat.S_IFDIR,
+                )
+                return metadata
+            except _windows_native.WindowsNativeError as exc:
+                raise UnsafePathError(str(exc)) from exc
+            finally:
+                if handle >= 0:
+                    _windows_close_handle(handle)
         try:
             path.chmod(mode)
             return path.lstat()
@@ -1706,6 +2026,34 @@ def secure_directory(path: Path) -> Path:
     if expanded.is_symlink():
         raise UnsafePathError(f"Refusing to use a symbolic-link directory: {expanded}")
     resolved = no_link_absolute_path(expanded)
+
+    windows_path = _windows_bound_relative_path(resolved)
+    if windows_path is not None:
+        state, relative = windows_path
+        if not relative.parts:
+            _require_windows_visible_directory_identity(
+                state.visible_root,
+                expected_identity=state.identity,
+            )
+            return resolved
+        handle = -1
+        try:
+            handle = _windows_native.ensure_relative_directory_path(
+                state.handle,
+                relative.parts,
+                require_existing_private_acl=state.strict_acl,
+            )
+            identity = _windows_directory_identity(handle)
+            _require_windows_visible_directory_identity(
+                resolved,
+                expected_identity=identity,
+            )
+            return resolved
+        except _windows_native.WindowsNativeError as exc:
+            raise UnsafePathError(str(exc)) from exc
+        finally:
+            if handle >= 0:
+                _windows_close_handle(handle)
 
     # pathlib's parents=True creates the whole missing chain before callers can
     # clear inherited ACLs. Build it one component at a time instead, securing
@@ -2539,6 +2887,18 @@ def _promote_path_no_replace_atomic(
         source_metadata = require_private_path(source, expected_type=expected_type)
         if expected_identity is not None and _identity(source_metadata) != expected_identity:
             raise UnsafePathError("The staged path identity changed before atomic promotion.")
+        source_bound = _windows_bound_relative_path(source)
+        destination_bound = _windows_bound_relative_path(destination)
+        if source_bound is None or destination_bound is None:
+            raise UnsafePathError("A trusted Windows output-root handle was not active.")
+        source_state, source_relative = source_bound
+        destination_state, destination_relative = destination_bound
+        if (
+            source_state is not destination_state
+            or not source_relative.parts
+            or not destination_relative.parts
+        ):
+            raise UnsafePathError("A Windows promotion path escaped its trusted output root.")
         try:
             destination.lstat()
         except FileNotFoundError:
@@ -2552,10 +2912,47 @@ def _promote_path_no_replace_atomic(
                 "The destination appeared before atomic promotion. Nothing was overwritten; "
                 "preserve the incomplete output and retry into a fresh destination."
             )
+        if expected_type != stat.S_IFDIR:
+            raise UnsafePathError(
+                "A Windows file promotion requires its already-held staging descriptor."
+            )
+        source_handle = -1
         try:
-            # Python's Windows os.rename contract is atomic and always refuses an
-            # existing destination; unlike os.replace, it cannot discard an existing path.
-            os.rename(source, destination)
+            source_handle = _windows_native.open_relative_directory_for_rename(
+                source_state.handle,
+                source_relative.parts,
+            )
+            information = _windows_native.handle_information(source_handle)
+            _require_windows_visible_artifact_identity(
+                source,
+                expected_identity=information.identity,
+                directory=True,
+                allow_delete_sharing=True,
+            )
+            _windows_native.rename_handle_relative(
+                source_handle,
+                destination_state.handle,
+                destination_relative.parts,
+                replace=False,
+            )
+            _require_windows_visible_artifact_identity(
+                destination,
+                expected_identity=information.identity,
+                directory=True,
+                allow_delete_sharing=True,
+            )
+        except _windows_native.WindowsObjectExistsError as exc:
+            raise OutputExistsError(
+                "The destination appeared before atomic promotion. Nothing was overwritten; "
+                "preserve the incomplete output and retry into a fresh destination."
+            ) from exc
+        except _windows_native.WindowsNativeError as exc:
+            raise UnsafePathError(str(exc)) from exc
+        finally:
+            if source_handle >= 0:
+                _windows_close_handle(source_handle)
+        try:
+            promoted = require_private_path(destination, expected_type=expected_type)
         except OSError as exc:
             if isinstance(exc, FileExistsError) or getattr(exc, "winerror", None) in {80, 183}:
                 raise OutputExistsError(
@@ -2563,7 +2960,6 @@ def _promote_path_no_replace_atomic(
                     "preserve the incomplete output and retry into a fresh destination."
                 ) from exc
             raise
-        promoted = require_private_path(destination, expected_type=expected_type)
         if _identity(promoted) != _identity(source_metadata):
             raise UnsafePathError("The promoted path identity changed unexpectedly.")
         return
@@ -2722,6 +3118,64 @@ def promote_file_no_replace_atomic(
     )
 
 
+def promote_open_file_no_replace_atomic(
+    descriptor: int,
+    source: Path,
+    destination: Path,
+    *,
+    expected_identity: tuple[int, int],
+    durable: bool = False,
+) -> None:
+    """Promote a held staging file without reopening its replaceable source name."""
+
+    if _running_on_windows():
+        bound = _windows_bound_relative_path(destination)
+        if bound is None:
+            raise UnsafePathError("A trusted Windows output-root handle was not active.")
+        state, relative = bound
+        if not relative.parts:
+            raise UnsafePathError("A Windows promotion destination was invalid.")
+        secure_directory(destination.parent)
+        try:
+            import msvcrt
+
+            native_handle = int(msvcrt.get_osfhandle(descriptor))
+            information = _windows_native.handle_information(native_handle)
+            opened = os.fstat(descriptor)
+            if _identity(opened) != expected_identity or information.is_directory:
+                raise UnsafePathError("The staged Windows file identity changed before promotion.")
+            if durable:
+                _windows_native.flush_handle(native_handle)
+            _windows_native.rename_handle_relative(
+                native_handle,
+                state.handle,
+                relative.parts,
+                replace=False,
+            )
+            promoted = destination.lstat()
+            if _identity(promoted) != expected_identity:
+                raise UnsafePathError("The promoted Windows file identity changed unexpectedly.")
+            return
+        except _windows_native.WindowsObjectExistsError as exc:
+            raise OutputExistsError(
+                "The destination appeared before atomic promotion. Nothing was overwritten; "
+                "preserve the incomplete output and retry into a fresh destination."
+            ) from exc
+        except _windows_native.WindowsNativeError as exc:
+            raise UnsafePathError(str(exc)) from exc
+        except (ImportError, OSError, TypeError, ValueError) as exc:
+            raise UnsafePathError(
+                "A held Windows staging file could not be promoted safely."
+            ) from exc
+
+    promote_file_no_replace_atomic(
+        source,
+        destination,
+        expected_identity=expected_identity,
+        durable=durable,
+    )
+
+
 def replace_path_atomic(source: Path, destination: Path, *, durable: bool = False) -> None:
     """Promote a sibling path with one atomic replace and optional parent durability."""
 
@@ -2735,7 +3189,7 @@ def private_text_writer(path: Path, *, newline: str | None = None) -> Iterator[T
     secure_directory(path.parent)
     descriptor = -1
     try:
-        descriptor = os.open(path, _open_flags(), 0o600)
+        descriptor = create_private_file_descriptor(path, exclusive=False)
         harden_private_descriptor(
             descriptor,
             expected_type=stat.S_IFREG,
@@ -2771,15 +3225,58 @@ def write_json_private_atomic(
 
     secure_directory(path.parent)
     temporary = path.with_name(f".{path.name}.{secrets.token_hex(8)}.partial")
-    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
-    if hasattr(os, "O_BINARY"):
-        flags |= os.O_BINARY
-    flags |= getattr(os, "O_CLOEXEC", 0)
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
+    windows_path = _windows_bound_relative_path(path)
+    if windows_path is not None:
+        state, relative = windows_path
+        if not relative.parts:
+            raise UnsafePathError("A private JSON path did not name an output descendant.")
+        descriptor = -1
+        try:
+            descriptor = create_private_file_descriptor(temporary, exclusive=True)
+            harden_private_descriptor(
+                descriptor,
+                expected_type=stat.S_IFREG,
+                mode=0o600,
+            )
+            payload = (json.dumps(value, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+            remaining = memoryview(payload)
+            while remaining:
+                written = os.write(descriptor, remaining)
+                if written <= 0:
+                    raise OSError("short private JSON write")
+                remaining = remaining[written:]
+            os.fsync(descriptor)
+            if before_replace is not None:
+                before_replace()
+            import msvcrt
+
+            native_handle = int(msvcrt.get_osfhandle(descriptor))
+            information = _windows_native.handle_information(native_handle)
+            if information.is_directory or information.is_reparse_point:
+                raise UnsafePathError("A private Windows JSON staging file was unsafe.")
+            _windows_native.validate_private_acl(native_handle)
+            _windows_native.flush_handle(native_handle)
+            _windows_native.rename_handle_relative(
+                native_handle,
+                state.handle,
+                relative.parts,
+                replace=True,
+            )
+            os.close(descriptor)
+            descriptor = -1
+            secure_file(path)
+            return
+        except _windows_native.WindowsNativeError as exc:
+            raise UnsafePathError(str(exc)) from exc
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+            with suppress(FileNotFoundError):
+                temporary.unlink()
+
     descriptor = -1
     try:
-        descriptor = os.open(temporary, flags, 0o600)
+        descriptor = create_private_file_descriptor(temporary, exclusive=True)
         harden_private_descriptor(
             descriptor,
             expected_type=stat.S_IFREG,
@@ -2805,13 +3302,9 @@ def write_json_private_atomic(
 
 def write_bytes_private(path: Path, value: bytes, *, exclusive: bool = False) -> None:
     secure_directory(path.parent)
-    flags = os.O_WRONLY | os.O_CREAT | (os.O_EXCL if exclusive else os.O_TRUNC)
-    flags |= getattr(os, "O_BINARY", 0) | getattr(os, "O_CLOEXEC", 0)
-    if hasattr(os, "O_NOFOLLOW"):
-        flags |= os.O_NOFOLLOW
     descriptor = -1
     try:
-        descriptor = os.open(path, flags, 0o600)
+        descriptor = create_private_file_descriptor(path, exclusive=exclusive)
         harden_private_descriptor(
             descriptor,
             expected_type=stat.S_IFREG,

--- a/tvtime_extractor/service.py
+++ b/tvtime_extractor/service.py
@@ -28,6 +28,7 @@ from .extract import (
     ExtractionResult,
     _held_backup_root,
     _require_bound_backup_root,
+    _windows_source_payload,
     extract_backup,
 )
 from .models import (
@@ -217,6 +218,38 @@ def _capture_backup_preflight_snapshot(
     *,
     cancellation: CancellationToken,
 ) -> tuple[BackupPreflightSnapshot, bytes, bytes]:
+    if os.name == "nt":
+        with _held_backup_root(backup) as (root_handle, root_identity, _visible):
+            manifest_plist, manifest_payload = _windows_source_payload(
+                Path("Manifest.plist"),
+                source_root_handle=root_handle,
+                maximum_bytes=MAXIMUM_MANIFEST_PLIST_BYTES,
+                retain_payload=True,
+            )
+            manifest_database, _ = _windows_source_payload(
+                Path("Manifest.db"),
+                source_root_handle=root_handle,
+            )
+            status_plist, status_payload = _windows_source_payload(
+                Path("Status.plist"),
+                source_root_handle=root_handle,
+                maximum_bytes=MAXIMUM_STATUS_PLIST_BYTES,
+                retain_payload=True,
+            )
+        if manifest_payload is None or status_payload is None:
+            raise TVTimeError("Required backup metadata could not be retained safely.")
+        return (
+            BackupPreflightSnapshot(
+                root_device=root_identity[0],
+                root_inode=root_identity[1],
+                manifest_plist=manifest_plist,
+                manifest_database=manifest_database,
+                status_plist=status_plist,
+            ),
+            manifest_payload,
+            status_payload,
+        )
+
     try:
         root_before = backup.lstat()
     except OSError as exc:

--- a/tvtime_extractor/windows_native.py
+++ b/tvtime_extractor/windows_native.py
@@ -1,0 +1,1088 @@
+from __future__ import annotations
+
+import contextlib
+import ctypes
+import os
+import platform
+import re
+import sys
+from collections.abc import Iterator, Sequence
+from ctypes import wintypes
+from dataclasses import dataclass
+
+
+class WindowsNativeError(OSError):
+    """A sanitized failure from the small Windows filesystem capability layer."""
+
+    def __init__(self, message: str, *, winerror: int = 0, ntstatus: int = 0) -> None:
+        super().__init__(winerror, message)
+        self.winerror = winerror
+        self.ntstatus = ntstatus
+
+
+class WindowsObjectExistsError(WindowsNativeError):
+    pass
+
+
+class WindowsUnsupportedError(WindowsNativeError):
+    pass
+
+
+@dataclass(frozen=True)
+class WindowsVolumeCapabilities:
+    filesystem_name: str
+    filesystem_flags: int
+
+
+@dataclass(frozen=True)
+class WindowsHandleInformation:
+    attributes: int
+    identity: tuple[int, int]
+    byte_size: int
+    last_write_time: int
+
+    @property
+    def is_directory(self) -> bool:
+        return bool(self.attributes & FILE_ATTRIBUTE_DIRECTORY)
+
+    @property
+    def is_reparse_point(self) -> bool:
+        return bool(self.attributes & FILE_ATTRIBUTE_REPARSE_POINT)
+
+
+class _FILETIME(ctypes.Structure):
+    _fields_ = [("low", wintypes.DWORD), ("high", wintypes.DWORD)]
+
+
+class _BY_HANDLE_FILE_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("file_attributes", wintypes.DWORD),
+        ("creation_time", _FILETIME),
+        ("last_access_time", _FILETIME),
+        ("last_write_time", _FILETIME),
+        ("volume_serial_number", wintypes.DWORD),
+        ("file_size_high", wintypes.DWORD),
+        ("file_size_low", wintypes.DWORD),
+        ("number_of_links", wintypes.DWORD),
+        ("file_index_high", wintypes.DWORD),
+        ("file_index_low", wintypes.DWORD),
+    ]
+
+
+class _UNICODE_STRING(ctypes.Structure):
+    _fields_ = [
+        ("Length", wintypes.USHORT),
+        ("MaximumLength", wintypes.USHORT),
+        ("Buffer", wintypes.LPWSTR),
+    ]
+
+
+class _OBJECT_ATTRIBUTES(ctypes.Structure):
+    _fields_ = [
+        ("Length", wintypes.ULONG),
+        ("RootDirectory", wintypes.HANDLE),
+        ("ObjectName", ctypes.POINTER(_UNICODE_STRING)),
+        ("Attributes", wintypes.ULONG),
+        ("SecurityDescriptor", wintypes.LPVOID),
+        ("SecurityQualityOfService", wintypes.LPVOID),
+    ]
+
+
+class _IO_STATUS_BLOCK_UNION(ctypes.Union):
+    _fields_ = [("Status", wintypes.LONG), ("Pointer", wintypes.LPVOID)]  # noqa: RUF012
+
+
+class _IO_STATUS_BLOCK(ctypes.Structure):
+    _anonymous_ = ("result",)
+    _fields_ = [("result", _IO_STATUS_BLOCK_UNION), ("Information", ctypes.c_size_t)]
+
+
+class _TOKEN_USER(ctypes.Structure):
+    _fields_ = [("User", wintypes.LPVOID), ("Attributes", wintypes.DWORD)]
+
+
+class _ACL_SIZE_INFORMATION(ctypes.Structure):
+    _fields_ = [
+        ("AceCount", wintypes.DWORD),
+        ("AclBytesInUse", wintypes.DWORD),
+        ("AclBytesFree", wintypes.DWORD),
+    ]
+
+
+class _ACE_HEADER(ctypes.Structure):
+    _fields_ = [
+        ("AceType", ctypes.c_ubyte),
+        ("AceFlags", ctypes.c_ubyte),
+        ("AceSize", wintypes.WORD),
+    ]
+
+
+class _ACCESS_ALLOWED_ACE(ctypes.Structure):
+    _fields_ = [
+        ("Header", _ACE_HEADER),
+        ("Mask", wintypes.DWORD),
+        ("SidStart", wintypes.DWORD),
+    ]
+
+
+class _FILE_RENAME_INFO(ctypes.Structure):
+    _fields_ = [
+        ("ReplaceIfExists", wintypes.BOOLEAN),
+        ("RootDirectory", wintypes.HANDLE),
+        ("FileNameLength", wintypes.DWORD),
+        ("FileName", wintypes.WCHAR * 1),
+    ]
+
+
+INVALID_HANDLE_VALUE = ctypes.c_void_p(-1).value
+
+FILE_ATTRIBUTE_DIRECTORY = 0x00000010
+FILE_ATTRIBUTE_NORMAL = 0x00000080
+FILE_ATTRIBUTE_TEMPORARY = 0x00000100
+FILE_ATTRIBUTE_REPARSE_POINT = 0x00000400
+FILE_FLAG_BACKUP_SEMANTICS = 0x02000000
+FILE_FLAG_OPEN_REPARSE_POINT = 0x00200000
+FILE_FLAG_WRITE_THROUGH = 0x80000000
+
+FILE_SHARE_READ = 0x00000001
+FILE_SHARE_WRITE = 0x00000002
+FILE_SHARE_DELETE = 0x00000004
+
+FILE_READ_DATA = 0x00000001
+FILE_LIST_DIRECTORY = 0x00000001
+FILE_WRITE_DATA = 0x00000002
+FILE_ADD_FILE = 0x00000002
+FILE_APPEND_DATA = 0x00000004
+FILE_ADD_SUBDIRECTORY = 0x00000004
+FILE_READ_EA = 0x00000008
+FILE_WRITE_EA = 0x00000010
+FILE_EXECUTE = 0x00000020
+FILE_TRAVERSE = 0x00000020
+FILE_READ_ATTRIBUTES = 0x00000080
+FILE_WRITE_ATTRIBUTES = 0x00000100
+
+DELETE = 0x00010000
+READ_CONTROL = 0x00020000
+WRITE_DAC = 0x00040000
+SYNCHRONIZE = 0x00100000
+GENERIC_READ = 0x80000000
+GENERIC_WRITE = 0x40000000
+
+FILE_OPEN = 0x00000001
+FILE_CREATE = 0x00000002
+FILE_OPEN_IF = 0x00000003
+FILE_OVERWRITE_IF = 0x00000005
+
+FILE_DIRECTORY_FILE = 0x00000001
+FILE_WRITE_THROUGH = 0x00000002
+FILE_SYNCHRONOUS_IO_NONALERT = 0x00000020
+FILE_NON_DIRECTORY_FILE = 0x00000040
+FILE_OPEN_REPARSE_POINT = 0x00200000
+
+OBJ_CASE_INSENSITIVE = 0x00000040
+STATUS_OBJECT_NAME_COLLISION = 0xC0000035
+STATUS_OBJECT_NAME_EXISTS = 0x40000000
+FILE_OPENED = 0x00000001
+FILE_CREATED = 0x00000002
+
+TOKEN_QUERY = 0x0008
+TOKEN_USER_CLASS = 1
+SDDL_REVISION_1 = 1
+FILE_PERSISTENT_ACLS = 0x00000008
+FILE_RENAME_INFO_CLASS = 3
+SE_FILE_OBJECT = 1
+DACL_SECURITY_INFORMATION = 0x00000004
+OWNER_SECURITY_INFORMATION = 0x00000001
+ACL_SIZE_INFORMATION_CLASS = 2
+SE_DACL_PROTECTED = 0x1000
+ACCESS_ALLOWED_ACE_TYPE = 0x00
+INHERITED_ACE = 0x10
+FILE_ALL_ACCESS = 0x001F01FF
+SYSTEM_SID = "S-1-5-18"
+
+_SAFE_COMPONENT = re.compile(r"^[^\\/:*?\"<>|\x00]+$")
+
+
+def _require_windows() -> None:
+    if os.name != "nt":
+        raise WindowsUnsupportedError("Windows native filesystem support is unavailable.")
+
+
+def require_supported_runtime() -> None:
+    _require_windows()
+    if ctypes.sizeof(ctypes.c_void_p) != 8 or platform.machine().casefold() not in {
+        "amd64",
+        "x86_64",
+    }:
+        raise WindowsUnsupportedError("Windows recovery requires 64-bit x64 Python.")
+    version = sys.getwindowsversion()
+    if version.major < 10 or version.build < 22000:
+        raise WindowsUnsupportedError("Windows recovery requires Windows 11 or later.")
+
+
+def validate_component(name: str) -> str:
+    if not isinstance(name, str) or name in {"", ".", ".."} or not _SAFE_COMPONENT.fullmatch(name):
+        raise WindowsNativeError("A Windows capability path component was invalid.")
+    return name
+
+
+def validate_relative_parts(parts: Sequence[str]) -> tuple[str, ...]:
+    if not parts:
+        raise WindowsNativeError("A Windows capability path was empty.")
+    return tuple(validate_component(part) for part in parts)
+
+
+def _dll(name: str) -> ctypes.WinDLL:
+    _require_windows()
+    try:
+        return ctypes.WinDLL(name, use_last_error=True)
+    except OSError as exc:
+        raise WindowsUnsupportedError("A required Windows system library was unavailable.") from exc
+
+
+def _handle_value(value: object) -> int:
+    if isinstance(value, int):
+        return value
+    candidate = getattr(value, "value", None)
+    return int(candidate) if isinstance(candidate, int) else -1
+
+
+def _last_error(message: str) -> WindowsNativeError:
+    return WindowsNativeError(message, winerror=int(ctypes.get_last_error() or 0))
+
+
+def close_handle(handle: int) -> None:
+    if not isinstance(handle, int) or isinstance(handle, bool) or handle <= 0:
+        return
+    kernel32 = _dll("kernel32")
+    close = kernel32.CloseHandle
+    close.argtypes = [wintypes.HANDLE]
+    close.restype = wintypes.BOOL
+    if not close(wintypes.HANDLE(handle)):
+        raise _last_error("A Windows capability handle could not be closed safely.")
+
+
+def handle_information(handle: int) -> WindowsHandleInformation:
+    if not isinstance(handle, int) or isinstance(handle, bool) or handle <= 0:
+        raise WindowsNativeError("A Windows capability handle was invalid.")
+    kernel32 = _dll("kernel32")
+    function = kernel32.GetFileInformationByHandle
+    function.argtypes = [wintypes.HANDLE, ctypes.POINTER(_BY_HANDLE_FILE_INFORMATION)]
+    function.restype = wintypes.BOOL
+    information = _BY_HANDLE_FILE_INFORMATION()
+    if not function(wintypes.HANDLE(handle), ctypes.byref(information)):
+        raise _last_error("A Windows capability handle could not be validated.")
+    return WindowsHandleInformation(
+        attributes=int(information.file_attributes),
+        identity=(
+            int(information.volume_serial_number),
+            (int(information.file_index_high) << 32) | int(information.file_index_low),
+        ),
+        byte_size=(int(information.file_size_high) << 32) | int(information.file_size_low),
+        last_write_time=(
+            (int(information.last_write_time.high) << 32) | int(information.last_write_time.low)
+        ),
+    )
+
+
+def volume_capabilities(handle: int) -> WindowsVolumeCapabilities:
+    kernel32 = _dll("kernel32")
+    function = kernel32.GetVolumeInformationByHandleW
+    function.argtypes = [
+        wintypes.HANDLE,
+        wintypes.LPWSTR,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+        ctypes.POINTER(wintypes.DWORD),
+        ctypes.POINTER(wintypes.DWORD),
+        wintypes.LPWSTR,
+        wintypes.DWORD,
+    ]
+    function.restype = wintypes.BOOL
+    flags = wintypes.DWORD()
+    filesystem = ctypes.create_unicode_buffer(64)
+    if not function(
+        wintypes.HANDLE(handle),
+        None,
+        0,
+        None,
+        None,
+        ctypes.byref(flags),
+        filesystem,
+        len(filesystem),
+    ):
+        raise _last_error("The Windows destination filesystem could not be inspected safely.")
+    return WindowsVolumeCapabilities(
+        filesystem_name=filesystem.value,
+        filesystem_flags=int(flags.value),
+    )
+
+
+def require_private_ntfs_volume(handle: int) -> None:
+    capabilities = volume_capabilities(handle)
+    if capabilities.filesystem_name.casefold() != "ntfs":
+        raise WindowsUnsupportedError("Windows recovery requires a local NTFS destination.")
+    if not capabilities.filesystem_flags & FILE_PERSISTENT_ACLS:
+        raise WindowsUnsupportedError(
+            "The Windows destination does not preserve and enforce access-control lists."
+        )
+
+
+def require_recovery_capabilities(handle: int) -> None:
+    """Probe the non-mutating Windows contract before any password is requested."""
+
+    require_supported_runtime()
+    information = handle_information(handle)
+    if not information.is_directory or information.is_reparse_point:
+        raise WindowsUnsupportedError("The Windows destination parent was not a safe directory.")
+    require_private_ntfs_volume(handle)
+    with private_security_descriptor() as descriptor:
+        if not descriptor:
+            raise WindowsUnsupportedError("Private Windows access controls could not be prepared.")
+    required_symbols = {
+        "ntdll": ("NtCreateFile", "RtlNtStatusToDosError"),
+        "kernel32": (
+            "FlushFileBuffers",
+            "GetFinalPathNameByHandleW",
+            "SetFileInformationByHandle",
+        ),
+    }
+    try:
+        for library, symbols in required_symbols.items():
+            loaded = _dll(library)
+            for symbol in symbols:
+                getattr(loaded, symbol)
+    except AttributeError as exc:
+        raise WindowsUnsupportedError(
+            "A required Windows filesystem capability was unavailable."
+        ) from exc
+
+
+def _current_user_sid_string() -> str:
+    advapi32 = _dll("advapi32")
+    kernel32 = _dll("kernel32")
+    get_process = kernel32.GetCurrentProcess
+    get_process.argtypes = []
+    get_process.restype = wintypes.HANDLE
+    process = get_process()
+    token = wintypes.HANDLE()
+    open_token = advapi32.OpenProcessToken
+    open_token.argtypes = [wintypes.HANDLE, wintypes.DWORD, ctypes.POINTER(wintypes.HANDLE)]
+    open_token.restype = wintypes.BOOL
+    if not open_token(process, TOKEN_QUERY, ctypes.byref(token)):
+        raise _last_error("The current Windows account could not be identified safely.")
+    try:
+        get_information = advapi32.GetTokenInformation
+        get_information.argtypes = [
+            wintypes.HANDLE,
+            wintypes.DWORD,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        get_information.restype = wintypes.BOOL
+        required = wintypes.DWORD()
+        get_information(token, TOKEN_USER_CLASS, None, 0, ctypes.byref(required))
+        if required.value <= 0:
+            raise _last_error("The current Windows account could not be identified safely.")
+        buffer = ctypes.create_string_buffer(required.value)
+        if not get_information(
+            token,
+            TOKEN_USER_CLASS,
+            buffer,
+            required.value,
+            ctypes.byref(required),
+        ):
+            raise _last_error("The current Windows account could not be identified safely.")
+        token_user = ctypes.cast(buffer, ctypes.POINTER(_TOKEN_USER)).contents
+        sid_text = wintypes.LPWSTR()
+        convert = advapi32.ConvertSidToStringSidW
+        convert.argtypes = [wintypes.LPVOID, ctypes.POINTER(wintypes.LPWSTR)]
+        convert.restype = wintypes.BOOL
+        if not convert(token_user.User, ctypes.byref(sid_text)):
+            raise _last_error("The current Windows account SID could not be encoded safely.")
+        try:
+            return str(sid_text.value)
+        finally:
+            local_free = kernel32.LocalFree
+            local_free.argtypes = [wintypes.HLOCAL]
+            local_free.restype = wintypes.HLOCAL
+            local_free(sid_text)
+    finally:
+        close_handle(_handle_value(token))
+
+
+@contextlib.contextmanager
+def private_security_descriptor() -> Iterator[wintypes.LPVOID]:
+    """Create a protected current-user-and-SYSTEM descriptor for one atomic create."""
+
+    sid = _current_user_sid_string()
+    sddl = f"O:{sid}D:P(A;;FA;;;SY)(A;;FA;;;{sid})"
+    advapi32 = _dll("advapi32")
+    kernel32 = _dll("kernel32")
+    descriptor = wintypes.LPVOID()
+    convert = advapi32.ConvertStringSecurityDescriptorToSecurityDescriptorW
+    convert.argtypes = [
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.LPVOID),
+        ctypes.POINTER(wintypes.DWORD),
+    ]
+    convert.restype = wintypes.BOOL
+    if not convert(sddl, SDDL_REVISION_1, ctypes.byref(descriptor), None):
+        raise _last_error("Private Windows access controls could not be prepared.")
+    try:
+        yield descriptor
+    finally:
+        if descriptor:
+            local_free = kernel32.LocalFree
+            local_free.argtypes = [wintypes.HLOCAL]
+            local_free.restype = wintypes.HLOCAL
+            local_free(descriptor)
+
+
+def _sid_string(sid: wintypes.LPVOID) -> str:
+    if not sid:
+        raise WindowsNativeError("A private Windows access-control identity was missing.")
+    advapi32 = _dll("advapi32")
+    kernel32 = _dll("kernel32")
+    converted = wintypes.LPWSTR()
+    function = advapi32.ConvertSidToStringSidW
+    function.argtypes = [wintypes.LPVOID, ctypes.POINTER(wintypes.LPWSTR)]
+    function.restype = wintypes.BOOL
+    if not function(sid, ctypes.byref(converted)):
+        raise _last_error("A private Windows access-control identity could not be inspected.")
+    try:
+        return str(converted.value)
+    finally:
+        local_free = kernel32.LocalFree
+        local_free.argtypes = [wintypes.HLOCAL]
+        local_free.restype = wintypes.HLOCAL
+        local_free(converted)
+
+
+def validate_private_acl(handle: int) -> None:
+    """Require one protected DACL containing only full-control user and SYSTEM ACEs."""
+
+    if not isinstance(handle, int) or isinstance(handle, bool) or handle <= 0:
+        raise WindowsNativeError("A Windows capability handle was invalid.")
+    advapi32 = _dll("advapi32")
+    kernel32 = _dll("kernel32")
+    owner = wintypes.LPVOID()
+    dacl = wintypes.LPVOID()
+    descriptor = wintypes.LPVOID()
+    get_security = advapi32.GetSecurityInfo
+    get_security.argtypes = [
+        wintypes.HANDLE,
+        ctypes.c_int,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.LPVOID),
+        ctypes.POINTER(wintypes.LPVOID),
+        ctypes.POINTER(wintypes.LPVOID),
+        ctypes.POINTER(wintypes.LPVOID),
+        ctypes.POINTER(wintypes.LPVOID),
+    ]
+    get_security.restype = wintypes.DWORD
+    result = int(
+        get_security(
+            wintypes.HANDLE(handle),
+            SE_FILE_OBJECT,
+            OWNER_SECURITY_INFORMATION | DACL_SECURITY_INFORMATION,
+            ctypes.byref(owner),
+            None,
+            ctypes.byref(dacl),
+            None,
+            ctypes.byref(descriptor),
+        )
+    )
+    if result:
+        raise WindowsNativeError(
+            "Private Windows access controls could not be inspected.",
+            winerror=result,
+        )
+    try:
+        if not descriptor or not dacl:
+            raise WindowsNativeError("A private Windows access-control list was missing.")
+        get_control = advapi32.GetSecurityDescriptorControl
+        get_control.argtypes = [
+            wintypes.LPVOID,
+            ctypes.POINTER(wintypes.WORD),
+            ctypes.POINTER(wintypes.DWORD),
+        ]
+        get_control.restype = wintypes.BOOL
+        control = wintypes.WORD()
+        revision = wintypes.DWORD()
+        if not get_control(descriptor, ctypes.byref(control), ctypes.byref(revision)):
+            raise _last_error("Private Windows access controls could not be validated.")
+        if not int(control.value) & SE_DACL_PROTECTED:
+            raise WindowsNativeError("Private Windows access controls allowed inheritance.")
+
+        get_acl_information = advapi32.GetAclInformation
+        get_acl_information.argtypes = [
+            wintypes.LPVOID,
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.c_int,
+        ]
+        get_acl_information.restype = wintypes.BOOL
+        acl_information = _ACL_SIZE_INFORMATION()
+        if not get_acl_information(
+            dacl,
+            ctypes.byref(acl_information),
+            ctypes.sizeof(acl_information),
+            ACL_SIZE_INFORMATION_CLASS,
+        ):
+            raise _last_error("Private Windows access controls could not be validated.")
+        if int(acl_information.AceCount) != 2:
+            raise WindowsNativeError("Private Windows access controls granted unexpected access.")
+
+        current_sid = _current_user_sid_string().casefold()
+        expected_sids = {current_sid, SYSTEM_SID.casefold()}
+        actual_sids: set[str] = set()
+        get_ace = advapi32.GetAce
+        get_ace.argtypes = [
+            wintypes.LPVOID,
+            wintypes.DWORD,
+            ctypes.POINTER(wintypes.LPVOID),
+        ]
+        get_ace.restype = wintypes.BOOL
+        for index in range(int(acl_information.AceCount)):
+            ace_pointer = wintypes.LPVOID()
+            if not get_ace(dacl, index, ctypes.byref(ace_pointer)):
+                raise _last_error("Private Windows access controls could not be validated.")
+            ace = ctypes.cast(ace_pointer, ctypes.POINTER(_ACCESS_ALLOWED_ACE)).contents
+            if (
+                int(ace.Header.AceType) != ACCESS_ALLOWED_ACE_TYPE
+                or int(ace.Header.AceFlags) & INHERITED_ACE
+                or int(ace.Mask) != FILE_ALL_ACCESS
+            ):
+                raise WindowsNativeError(
+                    "Private Windows access controls granted unexpected access."
+                )
+            sid_address = ctypes.addressof(ace) + _ACCESS_ALLOWED_ACE.SidStart.offset
+            actual_sids.add(_sid_string(wintypes.LPVOID(sid_address)).casefold())
+        if actual_sids != expected_sids or _sid_string(owner).casefold() != current_sid:
+            raise WindowsNativeError("Private Windows access controls had an unexpected owner.")
+    finally:
+        if descriptor:
+            local_free = kernel32.LocalFree
+            local_free.argtypes = [wintypes.HLOCAL]
+            local_free.restype = wintypes.HLOCAL
+            local_free(descriptor)
+
+
+def _ntstatus_error(status: int, message: str) -> WindowsNativeError:
+    normalized = int(status) & 0xFFFFFFFF
+    if normalized in {STATUS_OBJECT_NAME_COLLISION, STATUS_OBJECT_NAME_EXISTS}:
+        return WindowsObjectExistsError(message, ntstatus=normalized)
+    ntdll = _dll("ntdll")
+    convert = ntdll.RtlNtStatusToDosError
+    convert.argtypes = [wintypes.LONG]
+    convert.restype = wintypes.ULONG
+    winerror = int(convert(wintypes.LONG(status)))
+    return WindowsNativeError(message, winerror=winerror, ntstatus=normalized)
+
+
+def _nt_create_relative(
+    parent_handle: int,
+    name: str,
+    *,
+    desired_access: int,
+    share_access: int,
+    disposition: int,
+    options: int,
+    file_attributes: int,
+    security_descriptor: wintypes.LPVOID | None,
+) -> tuple[int, int]:
+    validate_component(name)
+    if not isinstance(parent_handle, int) or isinstance(parent_handle, bool) or parent_handle <= 0:
+        raise WindowsNativeError("A trusted Windows parent handle was unavailable.")
+    name_buffer = ctypes.create_unicode_buffer(name)
+    byte_length = len(name.encode("utf-16-le"))
+    unicode_name = _UNICODE_STRING(
+        Length=byte_length,
+        MaximumLength=byte_length + 2,
+        Buffer=ctypes.cast(name_buffer, wintypes.LPWSTR),
+    )
+    attributes = _OBJECT_ATTRIBUTES(
+        Length=ctypes.sizeof(_OBJECT_ATTRIBUTES),
+        RootDirectory=wintypes.HANDLE(parent_handle),
+        ObjectName=ctypes.pointer(unicode_name),
+        Attributes=OBJ_CASE_INSENSITIVE,
+        SecurityDescriptor=security_descriptor,
+        SecurityQualityOfService=None,
+    )
+    io_status = _IO_STATUS_BLOCK()
+    opened = wintypes.HANDLE()
+    ntdll = _dll("ntdll")
+    create = ntdll.NtCreateFile
+    create.argtypes = [
+        ctypes.POINTER(wintypes.HANDLE),
+        wintypes.DWORD,
+        ctypes.POINTER(_OBJECT_ATTRIBUTES),
+        ctypes.POINTER(_IO_STATUS_BLOCK),
+        ctypes.POINTER(ctypes.c_longlong),
+        wintypes.ULONG,
+        wintypes.ULONG,
+        wintypes.ULONG,
+        wintypes.ULONG,
+        wintypes.LPVOID,
+        wintypes.ULONG,
+    ]
+    create.restype = wintypes.LONG
+    status = int(
+        create(
+            ctypes.byref(opened),
+            desired_access,
+            ctypes.byref(attributes),
+            ctypes.byref(io_status),
+            None,
+            file_attributes,
+            share_access,
+            disposition,
+            options,
+            None,
+            0,
+        )
+    )
+    if status < 0:
+        raise _ntstatus_error(status, "A Windows capability object could not be created safely.")
+    handle = _handle_value(opened)
+    if handle in {-1, 0, INVALID_HANDLE_VALUE}:
+        raise WindowsNativeError("A Windows capability operation returned an invalid handle.")
+    return handle, int(io_status.Information)
+
+
+def create_fresh_directory(parent_handle: int, name: str) -> int:
+    with private_security_descriptor() as descriptor:
+        handle, _ = _nt_create_relative(
+            parent_handle,
+            name,
+            desired_access=(
+                FILE_LIST_DIRECTORY
+                | FILE_ADD_FILE
+                | FILE_ADD_SUBDIRECTORY
+                | FILE_TRAVERSE
+                | FILE_READ_ATTRIBUTES
+                | FILE_WRITE_ATTRIBUTES
+                | READ_CONTROL
+                | WRITE_DAC
+                | SYNCHRONIZE
+            ),
+            share_access=FILE_SHARE_READ | FILE_SHARE_WRITE,
+            disposition=FILE_CREATE,
+            options=(FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT | FILE_OPEN_REPARSE_POINT),
+            file_attributes=FILE_ATTRIBUTE_NORMAL,
+            security_descriptor=descriptor,
+        )
+    information = handle_information(handle)
+    if not information.is_directory or information.is_reparse_point:
+        with contextlib.suppress(Exception):
+            close_handle(handle)
+        raise WindowsNativeError("The fresh Windows destination was not a regular directory.")
+    try:
+        validate_private_acl(handle)
+    except BaseException:
+        with contextlib.suppress(Exception):
+            close_handle(handle)
+        raise
+    return handle
+
+
+def open_relative_directory(parent_handle: int, name: str, *, writable: bool) -> int:
+    desired = (
+        FILE_LIST_DIRECTORY | FILE_TRAVERSE | FILE_READ_ATTRIBUTES | READ_CONTROL | SYNCHRONIZE
+    )
+    if writable:
+        desired |= FILE_ADD_FILE | FILE_ADD_SUBDIRECTORY | FILE_WRITE_ATTRIBUTES | WRITE_DAC
+    handle, _ = _nt_create_relative(
+        parent_handle,
+        name,
+        desired_access=desired,
+        share_access=FILE_SHARE_READ | FILE_SHARE_WRITE,
+        disposition=FILE_OPEN,
+        options=FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT | FILE_OPEN_REPARSE_POINT,
+        file_attributes=FILE_ATTRIBUTE_NORMAL,
+        security_descriptor=None,
+    )
+    information = handle_information(handle)
+    if not information.is_directory or information.is_reparse_point:
+        with contextlib.suppress(Exception):
+            close_handle(handle)
+        raise WindowsNativeError("A Windows capability path traversed an unsafe directory.")
+    return handle
+
+
+def open_relative_directory_for_rename(root_handle: int, parts: Sequence[str]) -> int:
+    """Open one descendant directory with DELETE access while rejecting reparse traversal."""
+
+    components = validate_relative_parts(parts)
+    parent = root_handle
+    parent_owned = False
+    try:
+        for component in components[:-1]:
+            child = open_relative_directory(parent, component, writable=False)
+            if parent_owned:
+                close_handle(parent)
+            parent = child
+            parent_owned = True
+        handle, _ = _nt_create_relative(
+            parent,
+            components[-1],
+            desired_access=(
+                FILE_LIST_DIRECTORY
+                | FILE_TRAVERSE
+                | FILE_READ_ATTRIBUTES
+                | READ_CONTROL
+                | DELETE
+                | SYNCHRONIZE
+            ),
+            share_access=FILE_SHARE_READ | FILE_SHARE_WRITE,
+            disposition=FILE_OPEN,
+            options=(FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT | FILE_OPEN_REPARSE_POINT),
+            file_attributes=FILE_ATTRIBUTE_NORMAL,
+            security_descriptor=None,
+        )
+        information = handle_information(handle)
+        if not information.is_directory or information.is_reparse_point:
+            with contextlib.suppress(Exception):
+                close_handle(handle)
+            raise WindowsNativeError("A Windows promotion source was not a safe directory.")
+        return handle
+    finally:
+        if parent_owned:
+            close_handle(parent)
+
+
+def ensure_relative_directory(
+    parent_handle: int,
+    name: str,
+    *,
+    require_existing_private_acl: bool = True,
+) -> tuple[int, bool]:
+    with private_security_descriptor() as descriptor:
+        handle, result = _nt_create_relative(
+            parent_handle,
+            name,
+            desired_access=(
+                FILE_LIST_DIRECTORY
+                | FILE_ADD_FILE
+                | FILE_ADD_SUBDIRECTORY
+                | FILE_TRAVERSE
+                | FILE_READ_ATTRIBUTES
+                | FILE_WRITE_ATTRIBUTES
+                | READ_CONTROL
+                | WRITE_DAC
+                | SYNCHRONIZE
+            ),
+            share_access=FILE_SHARE_READ | FILE_SHARE_WRITE,
+            disposition=FILE_OPEN_IF,
+            options=(FILE_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT | FILE_OPEN_REPARSE_POINT),
+            file_attributes=FILE_ATTRIBUTE_NORMAL,
+            security_descriptor=descriptor,
+        )
+    information = handle_information(handle)
+    if not information.is_directory or information.is_reparse_point:
+        with contextlib.suppress(Exception):
+            close_handle(handle)
+        raise WindowsNativeError("A private Windows directory was unsafe.")
+    created = result == FILE_CREATED
+    if created or require_existing_private_acl:
+        try:
+            validate_private_acl(handle)
+        except BaseException:
+            with contextlib.suppress(Exception):
+                close_handle(handle)
+            raise
+    return handle, created
+
+
+def open_relative_regular_file(parent_handle: int, name: str) -> int:
+    handle, _ = _nt_create_relative(
+        parent_handle,
+        name,
+        desired_access=GENERIC_READ | FILE_READ_ATTRIBUTES | SYNCHRONIZE,
+        share_access=FILE_SHARE_READ,
+        disposition=FILE_OPEN,
+        options=FILE_NON_DIRECTORY_FILE | FILE_SYNCHRONOUS_IO_NONALERT | FILE_OPEN_REPARSE_POINT,
+        file_attributes=FILE_ATTRIBUTE_NORMAL,
+        security_descriptor=None,
+    )
+    information = handle_information(handle)
+    if information.is_directory or information.is_reparse_point:
+        with contextlib.suppress(Exception):
+            close_handle(handle)
+        raise WindowsNativeError("A Windows capability file was not a regular file.")
+    return handle
+
+
+def create_fresh_regular_file(parent_handle: int, name: str, *, temporary: bool = False) -> int:
+    attributes = FILE_ATTRIBUTE_NORMAL | (FILE_ATTRIBUTE_TEMPORARY if temporary else 0)
+    with private_security_descriptor() as descriptor:
+        handle, _ = _nt_create_relative(
+            parent_handle,
+            name,
+            desired_access=(
+                GENERIC_READ
+                | GENERIC_WRITE
+                | DELETE
+                | FILE_READ_ATTRIBUTES
+                | FILE_WRITE_ATTRIBUTES
+                | READ_CONTROL
+                | SYNCHRONIZE
+            ),
+            share_access=0,
+            disposition=FILE_CREATE,
+            options=(
+                FILE_NON_DIRECTORY_FILE
+                | FILE_SYNCHRONOUS_IO_NONALERT
+                | FILE_OPEN_REPARSE_POINT
+                | FILE_WRITE_THROUGH
+            ),
+            file_attributes=attributes,
+            security_descriptor=descriptor,
+        )
+    information = handle_information(handle)
+    if information.is_directory or information.is_reparse_point:
+        with contextlib.suppress(Exception):
+            close_handle(handle)
+        raise WindowsNativeError("A fresh private Windows file was unsafe.")
+    try:
+        validate_private_acl(handle)
+    except BaseException:
+        with contextlib.suppress(Exception):
+            close_handle(handle)
+        raise
+    return handle
+
+
+def create_or_replace_regular_file(
+    parent_handle: int,
+    name: str,
+    *,
+    exclusive: bool,
+    temporary: bool = False,
+) -> int:
+    """Create a private file, or atomically truncate the existing regular file."""
+
+    attributes = FILE_ATTRIBUTE_NORMAL | (FILE_ATTRIBUTE_TEMPORARY if temporary else 0)
+    with private_security_descriptor() as descriptor:
+        handle, _ = _nt_create_relative(
+            parent_handle,
+            name,
+            desired_access=(
+                GENERIC_READ
+                | GENERIC_WRITE
+                | DELETE
+                | FILE_READ_ATTRIBUTES
+                | FILE_WRITE_ATTRIBUTES
+                | READ_CONTROL
+                | WRITE_DAC
+                | SYNCHRONIZE
+            ),
+            share_access=0,
+            disposition=FILE_CREATE if exclusive else FILE_OVERWRITE_IF,
+            options=(
+                FILE_NON_DIRECTORY_FILE
+                | FILE_SYNCHRONOUS_IO_NONALERT
+                | FILE_OPEN_REPARSE_POINT
+                | FILE_WRITE_THROUGH
+            ),
+            file_attributes=attributes,
+            security_descriptor=descriptor,
+        )
+    information = handle_information(handle)
+    if information.is_directory or information.is_reparse_point:
+        with contextlib.suppress(Exception):
+            close_handle(handle)
+        raise WindowsNativeError("A private Windows file was unsafe.")
+    try:
+        validate_private_acl(handle)
+    except BaseException:
+        with contextlib.suppress(Exception):
+            close_handle(handle)
+        raise
+    return handle
+
+
+def open_relative_path(root_handle: int, parts: Sequence[str], *, directory: bool = False) -> int:
+    components = validate_relative_parts(parts)
+    current = root_handle
+    owned = False
+    try:
+        for component in components[:-1]:
+            child = open_relative_directory(current, component, writable=False)
+            if owned:
+                close_handle(current)
+            current = child
+            owned = True
+        result = (
+            open_relative_directory(current, components[-1], writable=False)
+            if directory
+            else open_relative_regular_file(current, components[-1])
+        )
+        return result
+    finally:
+        if owned:
+            close_handle(current)
+
+
+def ensure_relative_directory_path(
+    root_handle: int,
+    parts: Sequence[str],
+    *,
+    require_existing_private_acl: bool = True,
+) -> int:
+    components = validate_relative_parts(parts)
+    current = root_handle
+    owned = False
+    try:
+        for component in components:
+            child, _created = ensure_relative_directory(
+                current,
+                component,
+                require_existing_private_acl=require_existing_private_acl,
+            )
+            if owned:
+                close_handle(current)
+            current = child
+            owned = True
+        owned = False
+        return current
+    finally:
+        if owned:
+            close_handle(current)
+
+
+def create_relative_regular_file_path(
+    root_handle: int,
+    parts: Sequence[str],
+    *,
+    temporary: bool = False,
+    exclusive: bool = True,
+    require_existing_private_acl: bool = True,
+) -> int:
+    components = validate_relative_parts(parts)
+    parent = root_handle
+    owned = False
+    try:
+        if len(components) > 1:
+            parent = ensure_relative_directory_path(
+                root_handle,
+                components[:-1],
+                require_existing_private_acl=require_existing_private_acl,
+            )
+            owned = True
+        return create_or_replace_regular_file(
+            parent,
+            components[-1],
+            exclusive=exclusive,
+            temporary=temporary,
+        )
+    finally:
+        if owned:
+            close_handle(parent)
+
+
+def handle_to_file_descriptor(handle: int, *, flags: int) -> int:
+    _require_windows()
+    try:
+        import msvcrt
+
+        descriptor = msvcrt.open_osfhandle(handle, flags | getattr(os, "O_NOINHERIT", 0))
+    except (ImportError, OSError, TypeError, ValueError) as exc:
+        with contextlib.suppress(Exception):
+            close_handle(handle)
+        raise WindowsNativeError("A Windows handle could not be bound to Python safely.") from exc
+    if descriptor < 0:
+        with contextlib.suppress(Exception):
+            close_handle(handle)
+        raise WindowsNativeError("A Windows handle could not be bound to Python safely.")
+    return descriptor
+
+
+def flush_handle(handle: int) -> None:
+    kernel32 = _dll("kernel32")
+    function = kernel32.FlushFileBuffers
+    function.argtypes = [wintypes.HANDLE]
+    function.restype = wintypes.BOOL
+    if not function(wintypes.HANDLE(handle)):
+        raise _last_error("A private Windows file could not be flushed safely.")
+
+
+def final_path_from_handle(handle: int) -> str:
+    """Return the normalized local DOS path owned by one held filesystem handle."""
+
+    kernel32 = _dll("kernel32")
+    function = kernel32.GetFinalPathNameByHandleW
+    function.argtypes = [wintypes.HANDLE, wintypes.LPWSTR, wintypes.DWORD, wintypes.DWORD]
+    function.restype = wintypes.DWORD
+    required = int(function(wintypes.HANDLE(handle), None, 0, 0))
+    if required <= 0 or required > 32768:
+        raise _last_error("A held Windows directory path could not be resolved safely.")
+    buffer = ctypes.create_unicode_buffer(required + 1)
+    written = int(function(wintypes.HANDLE(handle), buffer, len(buffer), 0))
+    if written <= 0 or written >= len(buffer):
+        raise _last_error("A held Windows directory path could not be resolved safely.")
+    result = buffer.value
+    if not result.startswith("\\\\?\\") or result.casefold().startswith("\\\\?\\unc\\"):
+        raise WindowsUnsupportedError("A Windows capability path was not on local storage.")
+    return result
+
+
+def rename_handle_relative(
+    handle: int,
+    root_handle: int,
+    destination_parts: Sequence[str],
+    *,
+    replace: bool,
+) -> None:
+    """Rename an already-held file beneath a trusted root without reopening its source name."""
+
+    components = validate_relative_parts(destination_parts)
+    parent_handle = root_handle
+    parent_owned = False
+    try:
+        for component in components[:-1]:
+            child = open_relative_directory(parent_handle, component, writable=True)
+            if parent_owned:
+                close_handle(parent_handle)
+            parent_handle = child
+            parent_owned = True
+        destination = f"{final_path_from_handle(parent_handle)}\\{components[-1]}"
+        encoded = destination.encode("utf-16-le")
+        filename_offset = _FILE_RENAME_INFO.FileName.offset
+        allocation = ctypes.create_string_buffer(filename_offset + len(encoded) + 2)
+        information = ctypes.cast(
+            allocation,
+            ctypes.POINTER(_FILE_RENAME_INFO),
+        ).contents
+        information.ReplaceIfExists = bool(replace)
+        information.RootDirectory = None
+        information.FileNameLength = len(encoded)
+        destination_buffer = ctypes.addressof(allocation) + filename_offset
+        ctypes.memmove(destination_buffer, encoded, len(encoded))
+
+        kernel32 = _dll("kernel32")
+        rename = kernel32.SetFileInformationByHandle
+        rename.argtypes = [wintypes.HANDLE, ctypes.c_int, wintypes.LPVOID, wintypes.DWORD]
+        rename.restype = wintypes.BOOL
+        if not rename(
+            wintypes.HANDLE(handle),
+            FILE_RENAME_INFO_CLASS,
+            allocation,
+            len(allocation),
+        ):
+            error_number = int(ctypes.get_last_error() or 0)
+            if error_number in {80, 183}:
+                raise WindowsObjectExistsError(
+                    "The Windows promotion destination already existed.",
+                    winerror=error_number,
+                )
+            raise WindowsNativeError(
+                "A private Windows artifact could not be promoted safely.",
+                winerror=error_number,
+            )
+    finally:
+        if parent_owned:
+            close_handle(parent_handle)


### PR DESCRIPTION
- add secure NTFS handle-relative recovery with protected ACLs
- use descriptor-bound decryption and sanitized failure categories
- preserve valid plaintext when manifest sizes differ
- enable Windows extract and recover workflows
- add offline Refract series JSON conversion and documentation
- expand synthetic Windows, security, and conversion test coverage