### PR TITLE
feat: recover legacy URL cache records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes are documented here. The project follows semantic versioning.
 
+## Unreleased
+
+- Recover supported series, movies, favorites, watch events, and catalogue episodes from legacy
+  extensionless `NSKeyedArchiver` URL-cache files when those records are no longer present in
+  `DioCache.db`. The decoder remains offline, bounded, and excludes social-profile entries that
+  cannot be tied to a recovered episode catalogue.
+
 ## 0.2.0 - 2026-07-20
 
 Version 0.2.0 is published with Developer ID-signed, notarized, stapled Apple silicon and Intel

--- a/README.md
+++ b/README.md
@@ -247,10 +247,13 @@ the private output. It requires the primary TV Time domain
 selected regular file is copied below `TVTime-Extraction/raw/` with its domain and manifest-relative
 path preserved. File counts, sizes, and hashes are recorded privately before analysis.
 
-The primary parser reads the copied `Documents/DioCache.db`; an available image-cache database is
-catalogued as a bonus. Local caches can be incomplete, events can survive without names, and TV Time
-can change its schema. Missing data is stated rather than guessed. Retain the original encrypted
-backup until titles, favorites, episodes, watch events, and completion markers have been validated.
+The primary parser reads the copied `Documents/DioCache.db` and also recognizes supported legacy
+extensionless URL-cache archives in that same directory. Those old `NSKeyedArchiver` responses are
+decoded entirely offline; the extractor never replays their private request URLs. An available
+image-cache database is catalogued as a bonus. Local caches can be incomplete, events can survive
+without names, and TV Time can change its schema. Missing data is stated rather than guessed. Retain
+the original encrypted backup until titles, favorites, episodes, watch events, and completion
+markers have been validated.
 
 ## Read before using real data
 

--- a/docs/output-reference.md
+++ b/docs/output-reference.md
@@ -19,7 +19,7 @@ TVTime-Extraction/
     ├── TVTime-Recovered-Data.pdf      optional faithful printable report
     ├── recovery_state.json            full-recovery/report checkpoint
     ├── analysis_summary.json          parser, integrity, and table counts
-    ├── cache_index.csv                 opaque cache-source index
+    ├── cache_index.csv                 opaque database/legacy cache-source index
     ├── movie_library.csv               watched and saved movies
     ├── watched_movies.csv
     ├── movie_watchlist.csv
@@ -40,6 +40,12 @@ TVTime-Extraction/
 Exact rows depend on what remains in the local app cache. Empty tables, unnamed watch events, and
 missing image references are possible. Counts are not a guarantee of account completeness because
 this is local-backup recovery, not an official TV Time export.
+
+When present, compatible extensionless `NSKeyedArchiver` responses from the primary app's
+`Documents` directory contribute through the same normalized tables. Their filenames, request URLs,
+and account identifiers are not copied into those tables; `cache_index.csv` uses opaque source IDs.
+Series-like entries from old social-following payloads are accepted only when a recovered episode
+catalogue ties the same numeric series ID to actual episodes.
 
 **How to read the series count:** `Recovered series records` counts the recovered cache rows exactly;
 it is not silently deduplicated by title. The readable report separately shows named versus unnamed

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -249,9 +249,11 @@ completed encrypted backup, eject the device, and retry from that new backup.
 
 ## `DioCache.db` is missing or unsupported
 
-The current parser expects the copied primary app-domain file `Documents/DioCache.db`. A newer TV
-Time version may have changed its storage format, or the local cache may not include the database or
-recognized payloads.
+The current parser expects the copied primary app-domain file `Documents/DioCache.db`. When that
+database exists but no longer retains the library, analysis also checks compatible legacy
+extensionless URL-cache archives beside it. Those archives are decoded locally and never replayed
+over the network. A missing `DioCache.db` still stops this release, and a newer TV Time version may
+use an unsupported storage format.
 
 Preserve the private extraction. Report only the version, platform, parser status, and a synthetic or
 abstract description. Do not upload the database or cache.

--- a/script/validate_recovery_output.py
+++ b/script/validate_recovery_output.py
@@ -32,9 +32,11 @@ from tvtime_extractor.analyze import (  # noqa: E402
     MAXIMUM_CACHE_JSON_DEPTH,
     MAXIMUM_CACHE_JSON_NODES,
     MAXIMUM_CACHE_JSON_STRING_BYTES,
+    MAXIMUM_CACHE_KEY_BYTES,
     MAXIMUM_CACHE_PAYLOAD_BYTES,
     MAXIMUM_CACHE_ROWS,
     MAXIMUM_DERIVED_ROWS_PER_TABLE,
+    MAXIMUM_PLIST_BYTES,
     MAXIMUM_SQLITE_SNAPSHOT_FILE_BYTES,
     MAXIMUM_SQLITE_SNAPSHOT_TOTAL_BYTES,
     MAXIMUM_TOTAL_CACHE_JSON_NODES,
@@ -69,6 +71,11 @@ from tvtime_extractor.integrity import (  # noqa: E402
     SourceSnapshot,
     reconcile_raw_tree,
     source_snapshot_from_mapping,
+)
+from tvtime_extractor.legacy_cache import (  # noqa: E402
+    LegacyCacheNodeLimitError,
+    decode_legacy_cache_archive,
+    normalize_legacy_archives,
 )
 from tvtime_extractor.report import (  # noqa: E402
     _BOUND_ARTIFACTS,
@@ -109,6 +116,7 @@ from tvtime_extractor.safety import (  # noqa: E402
     _windows_open_locked_directory,
     no_link_absolute_path,
     private_source_id,
+    regular_binary_reader,
     require_private_descriptor,
     require_private_path,
     safe_domain_component,
@@ -465,7 +473,7 @@ def _strict_json(path: Path, *, maximum_bytes: int = MAXIMUM_JSON_BYTES) -> dict
     return value
 
 
-def _validate_json_complexity(value: object) -> None:
+def _validate_json_complexity(value: object) -> int:
     """Bound already byte-limited JSON before recursive consumers inspect it."""
 
     pending: list[tuple[object, int]] = [(value, 0)]
@@ -492,6 +500,7 @@ def _validate_json_complexity(value: object) -> None:
                 pending.append((child, depth + 1))
         elif isinstance(item, (list, tuple)):
             pending.extend((child, depth + 1) for child in item)
+    return visited
 
 
 def _require_directory(path: Path) -> None:
@@ -1248,9 +1257,12 @@ def _raw_cache_index(
     state: _State,
 ) -> tuple[list[dict[str, str]], list[tuple[str, object]]]:
     database = state.raw / PRIMARY_DOMAIN / "Documents" / "DioCache.db"
+    documents = database.parent
     rows: list[dict[str, str]] = []
     payload_records: list[tuple[str, object]] = []
     unique_hashes: dict[str, str] = {}
+    total_payload_bytes = 0
+    total_json_nodes = 0
     with _sqlite_snapshot(state, database) as connection:
         if str(connection.execute("PRAGMA quick_check").fetchone()[0]) != "ok":
             _fail()
@@ -1268,8 +1280,6 @@ def _raw_cache_index(
                 "SELECT key, subKey, content, statusCode FROM cache_dio ORDER BY key, subKey"
             )
         ) as records:
-            total_payload_bytes = 0
-            total_json_nodes = 0
             for row_number, (key, subkey, content, status_code) in enumerate(records, 1):
                 if row_number > MAXIMUM_SQLITE_ROWS:
                     _fail()
@@ -1323,6 +1333,93 @@ def _raw_cache_index(
                         "exported_file": "",
                     }
                 )
+    legacy_archives = []
+    with os.scandir(documents) as entries:
+        candidates = sorted(entries, key=lambda entry: entry.name)
+    for entry in candidates:
+        path = documents / entry.name
+        metadata = entry.stat(follow_symlinks=False)
+        if path == database or path.suffix or not stat.S_ISREG(metadata.st_mode):
+            continue
+        with regular_binary_reader(path, require_private=True) as (handle, metadata):
+            prefix = handle.read(8)
+            if prefix != b"bplist00":
+                continue
+            if metadata.st_size > MAXIMUM_PLIST_BYTES:
+                _fail()
+            archive_bytes = bytearray(prefix)
+            while len(archive_bytes) < metadata.st_size:
+                chunk = handle.read(min(1024 * 1024, metadata.st_size - len(archive_bytes)))
+                if not chunk:
+                    break
+                archive_bytes.extend(chunk)
+            if len(archive_bytes) != metadata.st_size:
+                _fail()
+        source_id = private_source_id(
+            "legacy-url-cache",
+            str(path.relative_to(documents)),
+        )
+        try:
+            archive = decode_legacy_cache_archive(
+                bytes(archive_bytes),
+                source_id=source_id,
+                observed_mtime_ns=metadata.st_mtime_ns,
+                maximum_nodes=MAXIMUM_CACHE_JSON_NODES,
+            )
+        except LegacyCacheNodeLimitError:
+            _fail()
+        if archive is None:
+            continue
+        try:
+            _bounded_utf8_length(
+                archive.url,
+                subject="legacy URL-cache request URL byte size",
+                maximum_bytes=MAXIMUM_CACHE_KEY_BYTES,
+            )
+        except UnsupportedSchemaError:
+            _fail()
+        node_count = _validate_json_complexity(archive.payload)
+        total_json_nodes += node_count
+        if total_json_nodes > MAXIMUM_TOTAL_CACHE_JSON_NODES:
+            _fail()
+        total_payload_bytes += len(archive.payload_bytes)
+        if total_payload_bytes > MAXIMUM_TOTAL_CACHE_PAYLOAD_BYTES:
+            _fail()
+        digest = hashlib.sha256(archive.payload_bytes).hexdigest()
+        duplicate_of = unique_hashes.get(digest, "")
+        unique_hashes.setdefault(digest, source_id)
+        data = _payload_data(archive.payload)
+        if isinstance(data, dict):
+            shape = "object"
+            data_type = str(data.get("type") or "")
+            objects = data.get("objects")
+            object_count: int | str = len(objects) if isinstance(objects, list) else ""
+        elif isinstance(data, list):
+            shape = "array"
+            data_type = ""
+            object_count = len(data)
+        else:
+            shape = type(data).__name__
+            data_type = ""
+            object_count = ""
+        if len(rows) >= MAXIMUM_SQLITE_ROWS:
+            _fail()
+        rows.append(
+            {
+                "source_id": source_id,
+                "status_code": "",
+                "bytes": str(len(archive.payload_bytes)),
+                "sha256": digest,
+                "duplicate_of": duplicate_of,
+                "json_valid": str(True),
+                "shape": shape,
+                "data_type": data_type,
+                "object_count": str(object_count),
+                "exported_file": "",
+            }
+        )
+        legacy_archives.append(archive)
+    payload_records.extend(normalize_legacy_archives(legacy_archives))
     return rows, payload_records
 
 
@@ -1436,22 +1533,32 @@ def _expected_core_tables(
         extended = item.get("extended") if isinstance(item.get("extended"), dict) else {}
         filters = _filters(item.get("filter"))
         if item.get("entity_type") == "movie":
-            watched_at = item.get("watched_at") or sorting_value(item, "watched_date", "watch_date")
+            raw_watched_at = item.get("watched_at") or sorting_value(
+                item,
+                "watched_date",
+                "watch_date",
+            )
+            watched_at = (
+                ""
+                if isinstance(raw_watched_at, str) and raw_watched_at.startswith("0001-01-01")
+                else raw_watched_at
+            )
+            is_watched = bool(extended.get("is_watched") or raw_watched_at)
             movie_library.append(
                 {
                     "uuid": item.get("uuid", ""),
                     "name": meta.get("name", ""),
                     "imdb_id": meta.get("imdb_id", ""),
                     "first_release_date": meta.get("first_release_date", ""),
-                    "library_status": "watched"
-                    if watched_at
-                    else (filters[0] if filters else "saved"),
+                    "library_status": (
+                        "watched" if is_watched else (filters[0] if filters else "saved")
+                    ),
                     "watched_at": watched_at,
                     "followed_at": sorting_value(item, "follow_date"),
                     "runtime_seconds": meta.get("runtime", ""),
                     "genres": " | ".join(str(value) for value in meta.get("genres") or []),
                     "filters": " | ".join(filters),
-                    "is_watched": extended.get("is_watched", ""),
+                    "is_watched": is_watched,
                     "created_at": item.get("created_at", ""),
                     "updated_at": item.get("updated_at", ""),
                 }
@@ -1472,8 +1579,8 @@ def _expected_core_tables(
                 }
             )
 
-    watched_movies = [row for row in movie_library if row["watched_at"]]
-    movie_watchlist = [row for row in movie_library if not row["watched_at"]]
+    watched_movies = [row for row in movie_library if row["is_watched"]]
+    movie_watchlist = [row for row in movie_library if not row["is_watched"]]
     movie_by_uuid = {str(row["uuid"]): row for row in movie_library}
     named_watch_events = [
         {**event, "movie_name": movie_by_uuid.get(str(event.get("uuid")), {}).get("name", "")}

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -38,6 +38,27 @@ def _json_bytes(value: object) -> bytes:
     return json.dumps(value, separators=(",", ":"), sort_keys=True).encode("utf-8")
 
 
+def write_legacy_archive(
+    path: Path,
+    *,
+    url: str,
+    payload: object,
+) -> None:
+    archive = {
+        "$archiver": "NSKeyedArchiver",
+        "$objects": [
+            "$null",
+            {"data": plistlib.UID(2), "response": plistlib.UID(3)},
+            json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+            url,
+        ],
+        "$top": {"root": plistlib.UID(1)},
+        "$version": 100_000,
+    }
+    path.write_bytes(plistlib.dumps(archive, fmt=plistlib.FMT_BINARY))
+    secure_file(path)
+
+
 def synthetic_payloads() -> list[tuple[str, str, bytes, int]]:
     library = {
         "data": {

--- a/tests/test_legacy_cache.py
+++ b/tests/test_legacy_cache.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import plistlib
+import sqlite3
+import tempfile
+import unittest
+from contextlib import closing
+from pathlib import Path
+from unittest import mock
+
+from tests.helpers import (
+    create_synthetic_extraction,
+    read_csv_rows,
+    refresh_synthetic_source_snapshot,
+    write_legacy_archive,
+)
+from tvtime_extractor.analyze import analyze_extraction
+from tvtime_extractor.errors import UnsupportedSchemaError
+from tvtime_extractor.extract import PRIMARY_DOMAIN
+from tvtime_extractor.legacy_cache import decode_legacy_cache_archive
+from tvtime_extractor.report import build_report
+
+SYNTHETIC_OWNER_ID = "900000001"
+SERIES_ID = 7100
+SOCIAL_PROFILE_ID = 7999
+MOVIE_ONE_UUID = "10000000-0000-4000-8000-000000000001"
+MOVIE_TWO_UUID = "10000000-0000-4000-8000-000000000002"
+
+
+def synthetic_movie(
+    uuid: str,
+    *,
+    name: str,
+    tvdb_id: int,
+    watched_at: str,
+    extended_is_watched: bool = True,
+) -> dict[str, object]:
+    return {
+        "uuid": uuid,
+        "entity_type": "movie",
+        "type": "follow",
+        "created_at": "2020-01-01T00:00:00Z",
+        "updated_at": "2020-01-02T00:00:00Z",
+        "watched_at": watched_at,
+        "extended": {"is_watched": extended_is_watched},
+        "filter": ["watched"],
+        "meta": {
+            "name": name,
+            "external_sources": [{"source": "tvdb", "id": str(tvdb_id)}],
+        },
+    }
+
+
+class LegacyURLCacheAnalysisTests(unittest.TestCase):
+    def test_decoder_requires_one_nskeyedarchiver_url_and_json_payload(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path = Path(temporary) / "synthetic-archive"
+            write_legacy_archive(
+                archive_path,
+                url="https://api.example.invalid/v2/cacheable/show/7100",
+                payload={"data": {"id": SERIES_ID, "name": "Synthetic Legacy Series"}},
+            )
+            archive_bytes = archive_path.read_bytes()
+
+            decoded = decode_legacy_cache_archive(
+                archive_bytes,
+                source_id="synthetic-source",
+                observed_mtime_ns=1,
+                maximum_nodes=100,
+            )
+            self.assertIsNotNone(decoded)
+
+            envelope = plistlib.loads(archive_bytes)
+            envelope["$archiver"] = "SyntheticOtherArchiver"
+            self.assertIsNone(
+                decode_legacy_cache_archive(
+                    plistlib.dumps(envelope, fmt=plistlib.FMT_BINARY),
+                    source_id="synthetic-source",
+                    observed_mtime_ns=1,
+                    maximum_nodes=100,
+                )
+            )
+
+            envelope["$archiver"] = "NSKeyedArchiver"
+            envelope["$objects"][2] = b"not-json"
+            self.assertIsNone(
+                decode_legacy_cache_archive(
+                    plistlib.dumps(envelope, fmt=plistlib.FMT_BINARY),
+                    source_id="synthetic-source",
+                    observed_mtime_ns=1,
+                    maximum_nodes=100,
+                )
+            )
+
+    def test_legacy_archives_share_the_cache_row_limit(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            extraction = create_synthetic_extraction(Path(temporary))
+            documents = extraction / "raw" / PRIMARY_DOMAIN / "Documents"
+            with closing(sqlite3.connect(documents / "DioCache.db")) as connection:
+                connection.execute("DELETE FROM cache_dio")
+                connection.commit()
+            write_legacy_archive(
+                documents / "synthetic-legacy-cache",
+                url=(
+                    "https://api.example.invalid/prod/v1/tracking/cgw/follows/user/"
+                    "900000003?entity_type=movie"
+                ),
+                payload={"data": {"type": "list", "objects": []}},
+            )
+            refresh_synthetic_source_snapshot(extraction)
+
+            with (
+                mock.patch("tvtime_extractor.analyze.MAXIMUM_CACHE_ROWS", 0),
+                self.assertRaises(UnsupportedSchemaError),
+            ):
+                analyze_extraction(extraction_directory=extraction)
+            self.assertFalse((extraction / "analysis").exists())
+
+    def test_legacy_url_cache_archives_recover_supported_records(self) -> None:
+        with tempfile.TemporaryDirectory() as temporary:
+            extraction = create_synthetic_extraction(Path(temporary))
+            documents = extraction / "raw" / PRIMARY_DOMAIN / "Documents"
+            cache = documents / "DioCache.db"
+            with closing(sqlite3.connect(cache)) as connection:
+                connection.execute("DELETE FROM cache_dio")
+                connection.commit()
+
+            movie_one = synthetic_movie(
+                MOVIE_ONE_UUID,
+                name="Synthetic Legacy Movie One",
+                tvdb_id=7201,
+                watched_at="2020-02-03T04:05:06Z",
+            )
+            movie_two = synthetic_movie(
+                MOVIE_TWO_UUID,
+                name="Synthetic Legacy Movie Two",
+                tvdb_id=7202,
+                watched_at="0001-01-01T00:00:00Z",
+                extended_is_watched=False,
+            )
+            write_legacy_archive(
+                documents / "legacy-cache-profile",
+                url=f"https://api.example.invalid/v2/user/{SYNTHETIC_OWNER_ID}",
+                payload={
+                    "data": {
+                        "id": int(SYNTHETIC_OWNER_ID),
+                        "created_at": "2020-01-01T00:00:00Z",
+                        "shows": [
+                            {
+                                "id": SERIES_ID,
+                                "name": "Synthetic Legacy Series",
+                                "status": "Continuing",
+                                "watched_episode_count": 1,
+                                "aired_episode_count": 2,
+                                "seasons": [
+                                    {
+                                        "number": 1,
+                                        "episodes": [
+                                            {
+                                                "id": 710001,
+                                                "number": 1,
+                                                "name": "Synthetic Episode One",
+                                                "air_date": "2020-01-01T00:00:00Z",
+                                                "is_special": False,
+                                            },
+                                            {
+                                                "id": 710002,
+                                                "number": 2,
+                                                "name": "Synthetic Episode Two",
+                                                "air_date": "2020-01-08T00:00:00Z",
+                                                "is_special": False,
+                                            },
+                                        ],
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                },
+            )
+            write_legacy_archive(
+                documents / "legacy-cache-following",
+                url=(
+                    "https://api.example.invalid/v2/cacheable/user/"
+                    f"{SYNTHETIC_OWNER_ID}/allfollowing"
+                ),
+                payload={
+                    "data": [
+                        {
+                            "id": SERIES_ID,
+                            "name": "Synthetic Legacy Series",
+                            "watched_episode_count": 1,
+                            "aired_episode_count": 2,
+                        },
+                        {
+                            "id": SOCIAL_PROFILE_ID,
+                            "name": "Synthetic Social Profile Must Stay Private",
+                        },
+                    ]
+                },
+            )
+            write_legacy_archive(
+                documents / "legacy-cache-movies",
+                url=(
+                    "https://api.example.invalid/prod/v1/tracking/cgw/follows/user/"
+                    f"{SYNTHETIC_OWNER_ID}?entity_type=movie"
+                ),
+                payload={"data": {"type": "list", "objects": [movie_one, movie_two]}},
+            )
+            write_legacy_archive(
+                documents / "legacy-cache-watches",
+                url=(
+                    "https://api.example.invalid/prod/v1/tracking/watches/user/"
+                    f"{SYNTHETIC_OWNER_ID}?entity_type=movie"
+                ),
+                payload={
+                    "data": {
+                        "type": "watch",
+                        "objects": [
+                            {
+                                "uuid": MOVIE_ONE_UUID,
+                                "entity_type": "movie",
+                                "type": "watch",
+                                "watched_at": "2020-02-03T04:05:06Z",
+                                "created_at": "2020-02-03T04:05:06Z",
+                                "updated_at": "2020-02-03T04:05:06Z",
+                            }
+                        ],
+                    }
+                },
+            )
+            write_legacy_archive(
+                documents / "legacy-cache-favorites",
+                url=(f"https://api.example.invalid/prod/v1/lists/cgw/user/{SYNTHETIC_OWNER_ID}"),
+                payload={
+                    "data": [
+                        {
+                            "id": "favorite-movies",
+                            "name": "Synthetic Favorite Movies",
+                            "type": "list",
+                            "objects": [movie_one],
+                        }
+                    ]
+                },
+            )
+            refresh_synthetic_source_snapshot(extraction)
+
+            summary = analyze_extraction(extraction_directory=extraction)
+
+            self.assertEqual(summary["series_library"], 1)
+            self.assertEqual(summary["movie_library"], 2)
+            self.assertEqual(summary["watched_movies"], 2)
+            self.assertEqual(summary["movie_watchlist"], 0)
+            self.assertEqual(summary["favorite_movies"], 1)
+            self.assertEqual(summary["watch_events"], 1)
+            self.assertEqual(summary["episode_cache_unique"], 2)
+            analysis = extraction / "analysis"
+            movies = read_csv_rows(analysis / "movie_library.csv")
+            self.assertEqual(
+                [row["name"] for row in movies],
+                ["Synthetic Legacy Movie One", "Synthetic Legacy Movie Two"],
+            )
+            self.assertEqual(movies[1]["watched_at"], "")
+            normalized_text = "\n".join(
+                path.read_text(encoding="utf-8") for path in analysis.iterdir() if path.is_file()
+            )
+            self.assertNotIn("Synthetic Social Profile Must Stay Private", normalized_text)
+            self.assertNotIn("api.example.invalid", normalized_text)
+
+            build_report(extraction_directory=extraction)
+            report = (analysis / "TVTime-Recovered-Data.md").read_text(encoding="utf-8")
+            self.assertIn("Synthetic Legacy Series", report)
+            self.assertIn("Synthetic Legacy Movie One", report)
+            self.assertNotIn("Synthetic Social Profile Must Stay Private", report)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_recovery_output_validator.py
+++ b/tests/test_recovery_output_validator.py
@@ -37,7 +37,11 @@ from script.validate_recovery_output import (
     _validate_json_complexity,
     validate_recovery_output,
 )
-from tests.helpers import create_synthetic_extraction, refresh_synthetic_source_snapshot
+from tests.helpers import (
+    create_synthetic_extraction,
+    refresh_synthetic_source_snapshot,
+    write_legacy_archive,
+)
 from tvtime_extractor.analyze import analyze_extraction
 from tvtime_extractor.errors import UnsafePathError
 from tvtime_extractor.extract import PRIMARY_DOMAIN
@@ -244,6 +248,51 @@ class RecoveryOutputValidatorTests(unittest.TestCase):
         refresh_synthetic_source_snapshot(extraction)
         analyze_extraction(extraction_directory=extraction)
         build_report(extraction_directory=extraction)
+        result = validate_recovery_output(output)
+        self.assertIn("data_parity", result.gates)
+
+    def test_legacy_zero_timestamp_matches_analyzer_and_validator_semantics(self) -> None:
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        output = Path(temporary.name) / "legacy-cache-output"
+        output.mkdir(mode=0o700)
+        extraction = create_synthetic_extraction(output)
+        documents = extraction / "raw" / PRIMARY_DOMAIN / "Documents"
+        with closing(sqlite3.connect(documents / "DioCache.db")) as connection:
+            connection.execute("DELETE FROM cache_dio")
+            connection.commit()
+        write_legacy_archive(
+            documents / "synthetic-legacy-movie-cache",
+            url=(
+                "https://api.example.invalid/prod/v1/tracking/cgw/follows/user/"
+                "900000002?entity_type=movie"
+            ),
+            payload={
+                "data": {
+                    "type": "list",
+                    "objects": [
+                        {
+                            "uuid": "40000000-0000-4000-8000-000000000001",
+                            "entity_type": "movie",
+                            "type": "follow",
+                            "created_at": "2020-01-01T00:00:00Z",
+                            "updated_at": "2020-01-02T00:00:00Z",
+                            "watched_at": "0001-01-01T00:00:00Z",
+                            "extended": {"is_watched": False},
+                            "filter": ["watched"],
+                            "meta": {"name": "Synthetic Sentinel Movie"},
+                        }
+                    ],
+                }
+            },
+        )
+        refresh_synthetic_source_snapshot(extraction)
+
+        summary = analyze_extraction(extraction_directory=extraction)
+        self.assertEqual(summary["watched_movies"], 1)
+        self.assertEqual(summary["movie_watchlist"], 0)
+        build_report(extraction_directory=extraction)
+
         result = validate_recovery_output(output)
         self.assertIn("data_parity", result.gates)
 

--- a/tvtime_extractor/analyze.py
+++ b/tvtime_extractor/analyze.py
@@ -25,6 +25,11 @@ from .errors import (
 )
 from .extract import PRIMARY_DOMAIN
 from .integrity import reconcile_raw_tree, source_snapshot_from_mapping
+from .legacy_cache import (
+    LegacyCacheNodeLimitError,
+    decode_legacy_cache_archive,
+    normalize_legacy_archives,
+)
 from .safety import (
     MAXIMUM_COMPLETION_MARKER_BYTES,
     anchored_existing_extraction_root,
@@ -889,6 +894,8 @@ def _analyze_extraction(
     unique_hashes: dict[str, str] = {}
     payload_records: list[tuple[str, object]] = []
     cache_exports: list[tuple[str, object, bool]] = []
+    total_json_nodes = 0
+    total_cache_payload_bytes = 0
     with readonly_sqlite(cache_db, require_private_source=True) as connection:
         try:
             quick_check = str(connection.execute("PRAGMA quick_check").fetchone()[0])
@@ -912,11 +919,11 @@ def _analyze_extraction(
                     "SELECT key, subKey, content, statusCode FROM cache_dio ORDER BY key, subKey"
                 )
             ) as cache_rows:
-                total_json_nodes = 0
                 for key, subkey, content, status_code in cache_rows:
                     if cancellation_check is not None:
                         cancellation_check()
                     raw_content = _cache_content_bytes(content)
+                    total_cache_payload_bytes += len(raw_content)
                     source_id = private_source_id(key, subkey)
                     digest = sha256_bytes(raw_content)
                     duplicate_of = unique_hashes.get(digest, "")
@@ -972,6 +979,109 @@ def _analyze_extraction(
         except sqlite3.Error as exc:
             raise TVTimeError("DioCache.db could not be read safely.") from exc
 
+    legacy_archives = []
+    documents = cache_db.parent
+    for path in regular_files:
+        if path == cache_db or path.parent != documents or path.suffix:
+            continue
+        if cancellation_check is not None:
+            cancellation_check()
+        with regular_binary_reader(path, require_private=True) as (handle, metadata):
+            prefix = handle.read(8)
+            if prefix != b"bplist00":
+                continue
+            if metadata.st_size > MAXIMUM_PLIST_BYTES:
+                raise _cache_limit_error(
+                    "legacy URL-cache property-list byte size",
+                    MAXIMUM_PLIST_BYTES,
+                )
+            archive_bytes = bytearray(prefix)
+            while len(archive_bytes) < metadata.st_size:
+                chunk = handle.read(min(1024 * 1024, metadata.st_size - len(archive_bytes)))
+                if not chunk:
+                    break
+                archive_bytes.extend(chunk)
+            if len(archive_bytes) != metadata.st_size:
+                raise UnsafePathError("A recovered legacy URL-cache archive changed while read.")
+        source_id = private_source_id(
+            "legacy-url-cache",
+            str(path.relative_to(documents)),
+        )
+        try:
+            archive = decode_legacy_cache_archive(
+                bytes(archive_bytes),
+                source_id=source_id,
+                observed_mtime_ns=metadata.st_mtime_ns,
+                maximum_nodes=MAXIMUM_CACHE_JSON_NODES,
+            )
+        except LegacyCacheNodeLimitError as exc:
+            raise _cache_limit_error(
+                "legacy URL-cache archive node count",
+                MAXIMUM_CACHE_JSON_NODES,
+            ) from exc
+        if archive is None:
+            continue
+        _bounded_utf8_length(
+            archive.url,
+            subject="legacy URL-cache request URL byte size",
+            maximum_bytes=MAXIMUM_CACHE_KEY_BYTES,
+        )
+        node_count = _validate_cache_json_complexity(
+            archive.payload,
+            cancellation_check=cancellation_check,
+        )
+        total_json_nodes += node_count
+        if total_json_nodes > MAXIMUM_TOTAL_CACHE_JSON_NODES:
+            raise _cache_limit_error(
+                "combined JSON node count",
+                MAXIMUM_TOTAL_CACHE_JSON_NODES,
+            )
+        total_cache_payload_bytes += len(archive.payload_bytes)
+        if total_cache_payload_bytes > MAXIMUM_TOTAL_CACHE_PAYLOAD_BYTES:
+            raise _cache_limit_error(
+                "combined cache-response byte size",
+                MAXIMUM_TOTAL_CACHE_PAYLOAD_BYTES,
+            )
+        digest = sha256_bytes(archive.payload_bytes)
+        duplicate_of = unique_hashes.get(digest, "")
+        unique_hashes.setdefault(digest, source_id)
+        exported_file = ""
+        if include_raw_cache:
+            exported_file = f"{source_id}.json"
+            cache_exports.append((exported_file, archive.payload, True))
+        data = _payload_data(archive.payload)
+        if isinstance(data, dict):
+            shape = "object"
+            data_type = str(data.get("type") or "")
+            objects = data.get("objects")
+            object_count: int | str = len(objects) if isinstance(objects, list) else ""
+        elif isinstance(data, list):
+            shape = "array"
+            data_type = ""
+            object_count = len(data)
+        else:
+            shape = type(data).__name__
+            data_type = ""
+            object_count = ""
+        if len(cache_index) >= MAXIMUM_CACHE_ROWS:
+            raise _cache_limit_error("combined cache-row count", MAXIMUM_CACHE_ROWS)
+        cache_index.append(
+            {
+                "source_id": source_id,
+                "status_code": "",
+                "bytes": len(archive.payload_bytes),
+                "sha256": digest,
+                "duplicate_of": duplicate_of,
+                "json_valid": True,
+                "shape": shape,
+                "data_type": data_type,
+                "object_count": object_count,
+                "exported_file": exported_file,
+            }
+        )
+        legacy_archives.append(archive)
+
+    payload_records.extend(normalize_legacy_archives(legacy_archives))
     recognized_payloads = sum(_is_supported_payload(payload) for _, payload in payload_records)
     if cache_index and not recognized_payloads:
         raise UnsupportedSchemaError(
@@ -1107,22 +1217,32 @@ def _analyze_extraction(
         extended = item.get("extended") if isinstance(item.get("extended"), dict) else {}
         filters = _filters(item.get("filter"))
         if item.get("entity_type") == "movie":
-            watched_at = item.get("watched_at") or sorting_value(item, "watched_date", "watch_date")
+            raw_watched_at = item.get("watched_at") or sorting_value(
+                item,
+                "watched_date",
+                "watch_date",
+            )
+            watched_at = (
+                ""
+                if isinstance(raw_watched_at, str) and raw_watched_at.startswith("0001-01-01")
+                else raw_watched_at
+            )
+            is_watched = bool(extended.get("is_watched") or raw_watched_at)
             movie_library.append(
                 {
                     "uuid": item.get("uuid", ""),
                     "name": meta.get("name", ""),
                     "imdb_id": meta.get("imdb_id", ""),
                     "first_release_date": meta.get("first_release_date", ""),
-                    "library_status": "watched"
-                    if watched_at
-                    else (filters[0] if filters else "saved"),
+                    "library_status": (
+                        "watched" if is_watched else (filters[0] if filters else "saved")
+                    ),
                     "watched_at": watched_at,
                     "followed_at": sorting_value(item, "follow_date"),
                     "runtime_seconds": meta.get("runtime", ""),
                     "genres": " | ".join(str(value) for value in meta.get("genres") or []),
                     "filters": " | ".join(filters),
-                    "is_watched": extended.get("is_watched", ""),
+                    "is_watched": is_watched,
                     "created_at": item.get("created_at", ""),
                     "updated_at": item.get("updated_at", ""),
                 }
@@ -1143,8 +1263,8 @@ def _analyze_extraction(
                 }
             )
 
-    watched_movies = [row for row in movie_library if row["watched_at"]]
-    movie_watchlist = [row for row in movie_library if not row["watched_at"]]
+    watched_movies = [row for row in movie_library if row["is_watched"]]
+    movie_watchlist = [row for row in movie_library if not row["is_watched"]]
     movie_by_uuid = {str(row["uuid"]): row for row in movie_library}
     named_watch_events = [
         {**event, "movie_name": movie_by_uuid.get(str(event.get("uuid")), {}).get("name", "")}

--- a/tvtime_extractor/legacy_cache.py
+++ b/tvtime_extractor/legacy_cache.py
@@ -1,0 +1,314 @@
+from __future__ import annotations
+
+import json
+import plistlib
+import re
+from collections import Counter
+from collections.abc import Iterator, Sequence
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlsplit
+
+
+@dataclass(frozen=True)
+class LegacyCacheArchive:
+    source_id: str
+    url: str
+    payload: object
+    payload_bytes: bytes
+    observed_mtime_ns: int
+
+
+class LegacyCacheNodeLimitError(ValueError):
+    pass
+
+
+def _iter_nested(value: object, *, maximum_nodes: int) -> Iterator[object]:
+    stack = [value]
+    visited = 0
+    while stack:
+        current = stack.pop()
+        visited += 1
+        if visited > maximum_nodes:
+            raise LegacyCacheNodeLimitError
+        yield current
+        if isinstance(current, dict):
+            stack.extend(current.values())
+        elif isinstance(current, list):
+            stack.extend(current)
+
+
+def decode_legacy_cache_archive(
+    data: bytes,
+    *,
+    source_id: str,
+    observed_mtime_ns: int,
+    maximum_nodes: int,
+) -> LegacyCacheArchive | None:
+    """Decode one extensionless NSKeyedArchiver cached-response envelope."""
+
+    try:
+        archive = plistlib.loads(data)
+    except (plistlib.InvalidFileException, ValueError, TypeError, OverflowError):
+        return None
+    if (
+        not isinstance(archive, dict)
+        or archive.get("$archiver") != "NSKeyedArchiver"
+        or not isinstance(archive.get("$objects"), list)
+        or not isinstance(archive.get("$top"), dict)
+    ):
+        return None
+    urls: list[str] = []
+    payloads: list[tuple[object, bytes]] = []
+    for value in _iter_nested(archive, maximum_nodes=maximum_nodes):
+        if isinstance(value, str) and value.startswith(("https://", "http://")):
+            urls.append(value)
+        elif isinstance(value, bytes):
+            try:
+                payloads.append((json.loads(value), value))
+            except (UnicodeDecodeError, json.JSONDecodeError, RecursionError):
+                continue
+    if len(urls) != 1 or len(payloads) != 1:
+        return None
+    payload, payload_bytes = payloads[0]
+    return LegacyCacheArchive(
+        source_id=source_id,
+        url=urls[0],
+        payload=payload,
+        payload_bytes=payload_bytes,
+        observed_mtime_ns=observed_mtime_ns,
+    )
+
+
+def _payload_data(payload: object) -> object:
+    if isinstance(payload, dict) and "data" in payload:
+        return payload.get("data")
+    return payload
+
+
+def _integer(value: object) -> int:
+    try:
+        return int(value or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _owner_user_id(archives: Sequence[LegacyCacheArchive]) -> str | None:
+    candidates: Counter[str] = Counter()
+    for archive in archives:
+        path = urlsplit(archive.url).path
+        if not any(
+            marker in path
+            for marker in (
+                "/allfollowing",
+                "/tracking/cgw/follows/user/",
+                "/tracking/watches/user/",
+                "/lists/cgw/user/",
+            )
+        ):
+            continue
+        match = re.search(r"/user/(\d+)", path)
+        if match is not None:
+            candidates[match.group(1)] += 1
+    return candidates.most_common(1)[0][0] if candidates else None
+
+
+def _episodes_from_show(show: dict[str, Any]) -> list[dict[str, Any]]:
+    show_id = show.get("id", "")
+    show_name = show.get("name", "")
+    seasons = show.get("seasons")
+    if not isinstance(seasons, list):
+        return []
+    episodes: list[dict[str, Any]] = []
+    for season in seasons:
+        if not isinstance(season, dict):
+            continue
+        season_episodes = season.get("episodes")
+        if not isinstance(season_episodes, list):
+            continue
+        for episode in season_episodes:
+            if not isinstance(episode, dict):
+                continue
+            episode_show = episode.get("show")
+            if not isinstance(episode_show, dict):
+                episode_show = {}
+            episode_season = episode.get("season")
+            if isinstance(episode_season, dict):
+                episode_season = episode_season.get("number")
+            if episode_season in (None, ""):
+                episode_season = season.get("number", "")
+            episodes.append(
+                {
+                    "id": episode.get("id", ""),
+                    "air_date": episode.get("air_date", ""),
+                    "show": {
+                        "id": episode_show.get("id") or show_id,
+                        "name": episode_show.get("name") or show_name,
+                    },
+                    "season_number": episode_season,
+                    "number": episode.get("number", ""),
+                    "name": episode.get("name", ""),
+                    "seen": episode.get("seen", ""),
+                    "seen_date": episode.get("seen_date", ""),
+                    "is_watched": episode.get("is_watched", ""),
+                    "is_special": episode.get("is_special", False),
+                    "runtime": episode.get("runtime", ""),
+                }
+            )
+    return episodes
+
+
+def _merge_show_candidates(candidates: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    fields = (
+        "id",
+        "name",
+        "country",
+        "status",
+        "created_at",
+        "updated_at",
+        "watched_episode_count",
+        "aired_episode_count",
+    )
+    merged: dict[str, Any] = {field: "" for field in fields}
+    for candidate in candidates:
+        for field in fields:
+            value = candidate.get(field)
+            if value not in (None, ""):
+                merged[field] = value
+    return merged
+
+
+def _series_object(show: dict[str, Any]) -> dict[str, Any]:
+    series_id = _integer(show.get("id"))
+    watched = _integer(show.get("watched_episode_count"))
+    aired = _integer(show.get("aired_episode_count"))
+    if watched <= 0:
+        user_status = "not_started_yet"
+    elif aired > 0 and watched >= aired:
+        user_status = "up_to_date"
+    else:
+        user_status = "continuing"
+    status = str(show.get("status") or "")
+    return {
+        "uuid": f"legacy-tvdb-{series_id}",
+        "entity_type": "series",
+        "created_at": show.get("created_at", ""),
+        "updated_at": show.get("updated_at", ""),
+        "filter": [user_status],
+        "meta": {
+            "id": series_id,
+            "name": show.get("name", ""),
+            "country": show.get("country", ""),
+            "is_ended": status.casefold() in {"ended", "canceled", "cancelled"},
+        },
+        "watch_status": {
+            "watched_episode_count": show.get("watched_episode_count", ""),
+            "aired_episode_count": show.get("aired_episode_count", ""),
+        },
+    }
+
+
+def normalize_legacy_archives(
+    archives: Sequence[LegacyCacheArchive],
+) -> list[tuple[str, object]]:
+    """Convert supported legacy endpoint shapes to the analyzer's in-memory shapes."""
+
+    ordered = sorted(archives, key=lambda item: (item.observed_mtime_ns, item.source_id))
+    owner_id = _owner_user_id(ordered)
+    normalized: list[tuple[str, object]] = []
+    show_candidates: dict[int, list[dict[str, Any]]] = {}
+    episodes: list[dict[str, Any]] = []
+    normalized_source_id = ordered[-1].source_id if ordered else "legacy-cache"
+
+    for archive in ordered:
+        path = urlsplit(archive.url).path
+        data = _payload_data(archive.payload)
+        if (
+            any(
+                marker in path
+                for marker in (
+                    "/tracking/cgw/follows/user/",
+                    "/tracking/watches/user/",
+                )
+            )
+            and isinstance(data, dict)
+            and isinstance(data.get("objects"), list)
+        ):
+            copied_data = dict(data)
+            copied_data.setdefault(
+                "type",
+                "watch" if "/tracking/watches/user/" in path else "list",
+            )
+            normalized.append((archive.source_id, {"data": copied_data}))
+
+        if "/lists/cgw/user/" in path and isinstance(data, list):
+            for item in data:
+                if (
+                    isinstance(item, dict)
+                    and item.get("id") in {"favorite-movies", "favorite-series"}
+                    and isinstance(item.get("objects"), list)
+                ):
+                    normalized.append(
+                        (
+                            archive.source_id,
+                            {
+                                "data": {
+                                    "type": "list",
+                                    "id": item.get("id"),
+                                    "objects": item["objects"],
+                                }
+                            },
+                        )
+                    )
+
+        if path.endswith("/allfollowing") and isinstance(data, list):
+            for item in data:
+                if isinstance(item, dict):
+                    show_id = _integer(item.get("id"))
+                    if show_id > 0:
+                        show_candidates.setdefault(show_id, []).append(item)
+
+        profile_match = re.fullmatch(r"/v2/user/(\d+)(?:/profile)?", path)
+        if (
+            owner_id is not None
+            and profile_match is not None
+            and profile_match.group(1) == owner_id
+            and isinstance(data, dict)
+            and isinstance(data.get("shows"), list)
+        ):
+            for item in data["shows"]:
+                if not isinstance(item, dict):
+                    continue
+                show_id = _integer(item.get("id"))
+                if show_id <= 0:
+                    continue
+                show_candidates.setdefault(show_id, []).append(item)
+                episodes.extend(_episodes_from_show(item))
+
+        if re.fullmatch(r"/v2/cacheable/show/\d+", path) and isinstance(data, dict):
+            show_id = _integer(data.get("id"))
+            if show_id > 0:
+                show_candidates.setdefault(show_id, []).append(data)
+                episodes.extend(_episodes_from_show(data))
+
+    valid_show_ids = {
+        _integer(episode.get("show", {}).get("id"))
+        for episode in episodes
+        if isinstance(episode.get("show"), dict)
+    }
+    valid_show_ids.discard(0)
+    series = [
+        _series_object(_merge_show_candidates(show_candidates[series_id]))
+        for series_id in sorted(show_candidates)
+        if series_id in valid_show_ids
+    ]
+    if series:
+        normalized.append(
+            (
+                normalized_source_id,
+                {"data": {"type": "list", "objects": series}},
+            )
+        )
+    if episodes:
+        normalized.append((normalized_source_id, {"data": episodes}))
+    return normalized


### PR DESCRIPTION
## Summary

- decode supported extensionless `NSKeyedArchiver` URL-cache responses beside `DioCache.db`
- normalize recovered series, movies, favorites, movie watch events, and catalogue episodes through the existing analysis contracts
- exclude social-profile rows that cannot be tied to a recovered episode catalogue
- preserve a watched state when the legacy payload uses the year-1 sentinel for an unknown exact timestamp
- extend the independent recovery-output validator and document the additional offline source

## Root cause

The analyzer only reconstructed records stored in `Documents/DioCache.db`. Older TV Time builds also persisted API responses as extensionless URL-cache archives, and those files can survive in a backup after the SQLite cache no longer contains the library.

## Privacy and safety

- all decoding is local and offline; cached request URLs are used only in memory for endpoint classification
- request URLs, account IDs, cache filenames, and source paths are not exported to recovered tables
- archives are read through the existing private no-follow reader
- plist bytes, JSON bytes/depth/nodes, combined cache rows, and derived rows remain bounded
- tests use synthetic titles, identifiers, URLs, and extraction trees only

## Validation

- `python -m ruff check .`
- `python -m ruff format --check .`
- full Python suite: 265 passed, 1 platform-specific skip
- Swift format lint
- `RecoveryOutputValidatorTests`: 34 passed in debug and 34 passed in release
- Swift release build
- source-bound sdist/wheel build, release verification, sdist metadata verification, and privacy scans
- `git diff --check`

The full Swift debug suite built and ran 112 tests; 3 pre-existing app-managed-storage tests failed closed because this checkout is under a local `Documents` location that macOS reports as cloud/shared. The validator suite affected by this change passes in both configurations.
