### PR TITLE
feat: add Suite TV Liberator exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes are documented here. The project follows semantic versioning.
 
+## Unreleased
+
+### Reports and recovery usability
+
+- Added sealed, owner-only TV Time Liberator ZIP exports for direct Suite TV import, with separate
+  exact confirmed state and explicitly bounded estimated-progress variants generated entirely
+  offline.
+- Preserved recovered TVDB IDs, rewatch counts, aggregate series progress, and episode-special flags
+  in normalized tables, with independent archive validation in Python and the native app.
+
 ## 0.2.0 - 2026-07-20
 
 Version 0.2.0 is published with Developer ID-signed, notarized, stapled Apple silicon and Intel

--- a/README.md
+++ b/README.md
@@ -105,6 +105,9 @@ A successful full recovery creates these primary reports under
   semantic tables; it works offline, contains no script, and does not request remote media
 - `TVTime-Recovered-Data.pdf`: optional print-friendly companion generated from the same report
   model; use the HTML report for tagged semantic structure with assistive technology
+- `Suite-TV-Liberator-confirmed.zip`: Suite TV import containing only exact recovered watch state
+- `Suite-TV-Liberator-estimated-progress.zip`: alternate Suite TV import that fills missing
+  per-episode state up to recovered aggregate series counts
 
 Markdown, HTML, and PDF are rendered from one shared safe display model, including identical
 missing-title placeholders and a copy-size-differences section when backup metadata and copied byte
@@ -116,6 +119,13 @@ The PDF is deliberately omitted when the available embedded font or shaping supp
 faithfully render every recovered character. This is a fidelity safeguard, not a failed recovery:
 the Markdown and offline HTML remain complete. Normalized CSV tables preserve the detailed private
 data used by the reports, including titles, favorites, episodes, and exact watch events.
+
+For Suite TV, prefer `Suite-TV-Liberator-confirmed.zip` when exactness matters. The estimated archive
+preserves every exact recovered watch and never estimates specials, but fills the oldest remaining
+regular episodes until each recovered aggregate watched count is reached. It cannot reconstruct
+which skipped, out-of-order, or repeatedly watched episodes produced that count. Both archives use
+the five-file TV Time Liberator layout and are created entirely offline; movies without a recovered
+positive TVDB identifier are omitted because Suite TV cannot identify them safely.
 
 Successful full recovery has two versioned machine-readable checkpoints:
 

--- a/docs/output-reference.md
+++ b/docs/output-reference.md
@@ -17,6 +17,8 @@ TVTime-Extraction/
     ├── TVTime-Recovered-Data.md       canonical complete readable report
     ├── TVTime-Recovered-Data.html     self-contained offline visual report
     ├── TVTime-Recovered-Data.pdf      optional faithful printable report
+    ├── Suite-TV-Liberator-confirmed.zip
+    ├── Suite-TV-Liberator-estimated-progress.zip
     ├── recovery_state.json            full-recovery/report checkpoint
     ├── analysis_summary.json          parser, integrity, and table counts
     ├── cache_index.csv                 opaque cache-source index
@@ -77,6 +79,19 @@ Markdown and offline HTML remain complete; no names are silently dropped to forc
 The visual reports show aggregate media-reference counts but do not embed or fetch remote images or
 videos. Detailed sanitized references remain in the CSV tables.
 
+## Suite TV import archives
+
+Both Suite TV archives reproduce the five root-level files emitted by TV Time Liberator:
+`shows.json`, `movies.json`, `favorites.json`, `lists.json`, and `activity_history.csv`. Generation
+uses only the already recovered private tables and performs no network lookup.
+
+Use `Suite-TV-Liberator-confirmed.zip` when exactness matters. It marks only episodes and movies whose
+watch state was recovered directly. Use `Suite-TV-Liberator-estimated-progress.zip` only when
+preserving a recovered aggregate series count is more useful than exact episode selection. That
+archive retains exact watches, never estimates specials, and fills the oldest unwatched regular
+episodes until the aggregate count is reached. It cannot infer skipped or out-of-order episodes.
+Movies without a recovered positive TVDB identifier are omitted from both archives.
+
 ## Completion markers and atomic promotion
 
 `metadata/run_state.json` uses the versioned v0.2 contract and begins as `incomplete`. It changes to
@@ -87,8 +102,9 @@ been revalidated.
 
 `analysis/recovery_state.json` uses the versioned v0.2 contract. It is written with
 `status: complete` in a private staging directory only
-after the Markdown and HTML reports are complete and the PDF has either been generated faithfully or
-explicitly omitted. It binds an exact ordered artifact set—including `metadata/domains.txt`—with
+after the Markdown, HTML, and Suite TV archives are complete and the PDF has either been generated
+faithfully or explicitly omitted. It binds an exact ordered artifact set—including
+`metadata/domains.txt`—with
 byte sizes, lowercase SHA-256 digests, aggregate extraction/analysis/report counts, and PDF presence
 state. The exact bounded serialized marker bytes are read back after writing and again immediately
 before the entire staged analysis directory is promoted atomically.
@@ -115,13 +131,15 @@ an analysis containing either advanced export cannot be promoted to a native-val
 
 ## CSV behavior
 
-CSV files preserve exact private timestamps and identifiers needed for a faithful personal archive.
+CSV and Suite TV files preserve exact private timestamps and identifiers needed for a faithful
+personal archive.
 Cells that could be interpreted as spreadsheet formulas are prefixed safely when written. The
 coordinates of those escaped cells are recorded in `analysis_summary.json`, allowing the report
 builder to reverse only those exact escapes when it reconstructs readable text.
 
-Opening a CSV in spreadsheet software can create Recent Items, autosave, cache, or sync copies.
-Import it only in a private local application and never upload it to an online spreadsheet service.
+Opening a CSV in spreadsheet software or importing a ZIP into Suite TV can create Recent Items,
+autosave, cache, or sync copies. Import either only in a private local application and never upload a
+recovery artifact to an online conversion service.
 
 ## Permissions and sensitivity
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -75,8 +75,10 @@ By default:
 - readable reports omit stable UUIDs and shorten recognized timestamps to calendar dates; and
 - visual reports show media-reference counts without embedding or fetching remote media.
 
-The normalized CSV files still contain private identifiers and exact timestamps where needed for a
-faithful archive. The readable reports are safer to inspect, not safe to publish.
+The normalized CSV files and Suite TV import ZIPs still contain private identifiers and exact
+timestamps where needed for a faithful archive. The readable reports are safer to inspect, not safe
+to publish. Creating the Suite TV archives is offline, but importing one hands its contents to Suite
+TV and whatever local storage, backup, or sync behavior that app uses.
 
 The advanced `extract --include-decrypted-manifest` and `analyze --include-raw-cache` CLI options
 can expose much more device or account information. They are intentionally unavailable in the
@@ -107,7 +109,8 @@ Do not attach, commit, publish, or send any of the following, even to a private 
 
 - an iOS or iPadOS backup, `Manifest.plist`, `Status.plist`, or decrypted manifest;
 - `TVTime-Extraction`, `raw`, `metadata`, `analysis`, or `cache_responses`;
-- SQLite databases, property lists, cookies, profile payloads, completion markers, reports, or CSVs;
+- SQLite databases, property lists, cookies, profile payloads, completion markers, reports, CSVs, or
+  Suite TV import ZIPs;
 - backup passwords, device IDs, stable user IDs, hashes, private URLs, or local paths; or
 - screenshots, screen recordings, PDFs, or previews containing recovered titles or history.
 

--- a/macos/Sources/TVTimeRecoveryCore/RecoveryOutputValidator.swift
+++ b/macos/Sources/TVTimeRecoveryCore/RecoveryOutputValidator.swift
@@ -728,6 +728,7 @@ enum RecoveryOutputValidator {
     case markdown
     case html
     case pdf
+    case zip
   }
 
   private struct ExpectedArtifact {
@@ -785,7 +786,7 @@ enum RecoveryOutputValidator {
       csvArtifact(
         "movie_library",
         "movie_library.csv",
-        "uuid,name,imdb_id,first_release_date,library_status,watched_at,followed_at,runtime_seconds,genres,filters,is_watched,created_at,updated_at"
+        "uuid,name,imdb_id,tvdb_id,first_release_date,library_status,watched_at,followed_at,runtime_seconds,genres,filters,is_watched,rewatch_count,created_at,updated_at"
       ),
       csvArtifact(
         "watch_events",
@@ -795,7 +796,7 @@ enum RecoveryOutputValidator {
       csvArtifact(
         "episode_cache",
         "episode_cache.csv",
-        "source_id,episode_id,show_id,show_name,season,episode,episode_name,air_date,seen,seen_date,is_watched,runtime"
+        "source_id,episode_id,show_id,show_name,season,episode,episode_name,air_date,seen,seen_date,is_special,is_watched,runtime"
       ),
       csvArtifact(
         "sqlite_integrity",
@@ -810,17 +811,17 @@ enum RecoveryOutputValidator {
       csvArtifact(
         "series_library",
         "series_library.csv",
-        "uuid,series_id,name,country,is_ended,followed_at,last_watch_date,filters,created_at,updated_at"
+        "uuid,series_id,name,country,is_ended,followed_at,last_watch_date,filters,watched_episode_count,aired_episode_count,created_at,updated_at"
       ),
       csvArtifact(
         "watched_movies",
         "watched_movies.csv",
-        "uuid,name,imdb_id,first_release_date,library_status,watched_at,followed_at,runtime_seconds,genres,filters,is_watched,created_at,updated_at"
+        "uuid,name,imdb_id,tvdb_id,first_release_date,library_status,watched_at,followed_at,runtime_seconds,genres,filters,is_watched,rewatch_count,created_at,updated_at"
       ),
       csvArtifact(
         "movie_watchlist",
         "movie_watchlist.csv",
-        "uuid,name,imdb_id,first_release_date,library_status,watched_at,followed_at,runtime_seconds,genres,filters,is_watched,created_at,updated_at"
+        "uuid,name,imdb_id,tvdb_id,first_release_date,library_status,watched_at,followed_at,runtime_seconds,genres,filters,is_watched,rewatch_count,created_at,updated_at"
       ),
       csvArtifact(
         "favorite_shows",
@@ -835,7 +836,7 @@ enum RecoveryOutputValidator {
       csvArtifact(
         "episode_cache_unique",
         "episode_cache_unique.csv",
-        "source_id,episode_id,show_id,show_name,season,episode,episode_name,air_date,seen,seen_date,is_watched,runtime"
+        "source_id,episode_id,show_id,show_name,season,episode,episode_name,air_date,seen,seen_date,is_special,is_watched,runtime"
       ),
       csvArtifact(
         "watch_events_named",
@@ -856,6 +857,20 @@ enum RecoveryOutputValidator {
         "image_cache_references",
         "image_cache_references.csv",
         "cache_id,category,intended_filename,declared_bytes,width,height,source_url,cached_request_url,valid_till,touched"
+      ),
+      ExpectedArtifact(
+        id: "suite_tv_liberator_confirmed",
+        relativePath: "analysis/Suite-TV-Liberator-confirmed.zip",
+        maximumBytes: maximumArtifactBytes,
+        format: .zip,
+        captureAll: false
+      ),
+      ExpectedArtifact(
+        id: "suite_tv_liberator_estimated_progress",
+        relativePath: "analysis/Suite-TV-Liberator-estimated-progress.zip",
+        maximumBytes: maximumArtifactBytes,
+        format: .zip,
+        captureAll: false
       ),
       ExpectedArtifact(
         id: "markdown_report",
@@ -2361,6 +2376,8 @@ enum RecoveryOutputValidator {
         prefix.starts(with: Data("<!doctype html>".utf8))
       case .pdf:
         prefix.starts(with: Data("%PDF-".utf8))
+      case .zip:
+        prefix.starts(with: Data([0x50, 0x4B, 0x03, 0x04]))
       }
     guard valid else {
       throw RecoveryOutputValidationError.artifactIntegrityFailure

--- a/macos/Tests/TVTimeRecoveryCoreTests/RecoveryOutputValidatorTests.swift
+++ b/macos/Tests/TVTimeRecoveryCoreTests/RecoveryOutputValidatorTests.swift
@@ -739,6 +739,27 @@ final class RecoveryOutputValidatorTests {
   }
 
   @Test
+  func testRejectsResealedSuiteTVArchiveWithWrongSignature() throws {
+    let summary = TestFixtures.summary()
+    let root = try makeOutput(summary: summary)
+    let archive = root.appendingPathComponent(
+      "TVTime-Extraction/analysis/Suite-TV-Liberator-confirmed.zip"
+    )
+    let original = try Data(contentsOf: archive)
+    var corrupted = Data("NOPE".utf8)
+    corrupted.append(Data(repeating: 0x20, count: original.count - corrupted.count))
+    try TestFixtures.writePrivate(corrupted, at: archive)
+    try TestFixtures.refreshArtifactBinding(
+      beneath: root,
+      id: "suite_tv_liberator_confirmed"
+    )
+
+    assertValidationError(.artifactIntegrityFailure) {
+      try RecoveryOutputValidator.validate(summary, beneath: root)
+    }
+  }
+
+  @Test
   func testRejectsMarkerHashSizeCountPDFAndArtifactSetMismatches() throws {
     let summary = TestFixtures.summary()
     let badHash = try makeOutput(summary: summary)

--- a/macos/Tests/TVTimeRecoveryCoreTests/TestFixtures.swift
+++ b/macos/Tests/TVTimeRecoveryCoreTests/TestFixtures.swift
@@ -281,6 +281,14 @@ enum TestFixtures {
       Data("<!doctype html><title>Recovered data</title>\n".utf8),
       at: root.appendingPathComponent(summary.artifacts.visualReport)
     )
+    try writePrivate(
+      Data([0x50, 0x4B, 0x03, 0x04, 0x00]),
+      at: analysis.appendingPathComponent("Suite-TV-Liberator-confirmed.zip")
+    )
+    try writePrivate(
+      Data([0x50, 0x4B, 0x03, 0x04, 0x00]),
+      at: analysis.appendingPathComponent("Suite-TV-Liberator-estimated-progress.zip")
+    )
     if let pdfReport = summary.artifacts.pdfReport {
       try writePrivate(Data("%PDF-1.4\n".utf8), at: root.appendingPathComponent(pdfReport))
     }
@@ -396,6 +404,11 @@ enum TestFixtures {
     ("trailer_references", "analysis/trailer_references.csv"),
     ("media_url_inventory", "analysis/media_url_inventory.csv"),
     ("image_cache_references", "analysis/image_cache_references.csv"),
+    ("suite_tv_liberator_confirmed", "analysis/Suite-TV-Liberator-confirmed.zip"),
+    (
+      "suite_tv_liberator_estimated_progress",
+      "analysis/Suite-TV-Liberator-estimated-progress.zip"
+    ),
     ("markdown_report", "analysis/TVTime-Recovered-Data.md"),
     ("html_report", "analysis/TVTime-Recovered-Data.html"),
   ]
@@ -407,7 +420,7 @@ enum TestFixtures {
     ),
     (
       "movie_library.csv",
-      "uuid,name,imdb_id,first_release_date,library_status,watched_at,followed_at,runtime_seconds,genres,filters,is_watched,created_at,updated_at"
+      "uuid,name,imdb_id,tvdb_id,first_release_date,library_status,watched_at,followed_at,runtime_seconds,genres,filters,is_watched,rewatch_count,created_at,updated_at"
     ),
     (
       "watch_events.csv",
@@ -415,21 +428,21 @@ enum TestFixtures {
     ),
     (
       "episode_cache.csv",
-      "source_id,episode_id,show_id,show_name,season,episode,episode_name,air_date,seen,seen_date,is_watched,runtime"
+      "source_id,episode_id,show_id,show_name,season,episode,episode_name,air_date,seen,seen_date,is_special,is_watched,runtime"
     ),
     ("sqlite_integrity.csv", "relative_path,bytes,quick_check,schema_objects"),
     ("plist_key_inventory.csv", "relative_path,format,top_level_keys"),
     (
       "series_library.csv",
-      "uuid,series_id,name,country,is_ended,followed_at,last_watch_date,filters,created_at,updated_at"
+      "uuid,series_id,name,country,is_ended,followed_at,last_watch_date,filters,watched_episode_count,aired_episode_count,created_at,updated_at"
     ),
     (
       "watched_movies.csv",
-      "uuid,name,imdb_id,first_release_date,library_status,watched_at,followed_at,runtime_seconds,genres,filters,is_watched,created_at,updated_at"
+      "uuid,name,imdb_id,tvdb_id,first_release_date,library_status,watched_at,followed_at,runtime_seconds,genres,filters,is_watched,rewatch_count,created_at,updated_at"
     ),
     (
       "movie_watchlist.csv",
-      "uuid,name,imdb_id,first_release_date,library_status,watched_at,followed_at,runtime_seconds,genres,filters,is_watched,created_at,updated_at"
+      "uuid,name,imdb_id,tvdb_id,first_release_date,library_status,watched_at,followed_at,runtime_seconds,genres,filters,is_watched,rewatch_count,created_at,updated_at"
     ),
     (
       "favorite_shows.csv",
@@ -441,7 +454,7 @@ enum TestFixtures {
     ),
     (
       "episode_cache_unique.csv",
-      "source_id,episode_id,show_id,show_name,season,episode,episode_name,air_date,seen,seen_date,is_watched,runtime"
+      "source_id,episode_id,show_id,show_name,season,episode,episode_name,air_date,seen,seen_date,is_special,is_watched,runtime"
     ),
     (
       "watch_events_named.csv",

--- a/script/validate_recovery_output.py
+++ b/script/validate_recovery_output.py
@@ -11,6 +11,7 @@ import sqlite3
 import stat
 import sys
 import tempfile
+import zipfile
 from collections import Counter
 from collections.abc import Callable, Iterator, Mapping, Sequence
 from contextlib import closing, contextmanager, redirect_stderr, redirect_stdout
@@ -41,6 +42,7 @@ from tvtime_extractor.analyze import (  # noqa: E402
     MAXIMUM_TOTAL_CACHE_PAYLOAD_BYTES,
     _bounded_utf8_length,
     _cache_content_bytes,
+    _external_source_id,
     _favorite_rows,
     _filters,
     _integer,
@@ -116,6 +118,7 @@ from tvtime_extractor.safety import (  # noqa: E402
     sanitize_public_url,
     validate_file_id,
 )
+from tvtime_extractor.suite_tv import LIBERATOR_FILENAMES  # noqa: E402
 from tvtime_extractor.visual_report import (  # noqa: E402
     HTML_REPORT_FILENAME,
     PDF_FIDELITY_WARNING,
@@ -179,6 +182,7 @@ CSV_FIELDS: dict[str, tuple[str, ...]] = {
         "uuid",
         "name",
         "imdb_id",
+        "tvdb_id",
         "first_release_date",
         "library_status",
         "watched_at",
@@ -187,6 +191,7 @@ CSV_FIELDS: dict[str, tuple[str, ...]] = {
         "genres",
         "filters",
         "is_watched",
+        "rewatch_count",
         "created_at",
         "updated_at",
     ),
@@ -210,6 +215,7 @@ CSV_FIELDS: dict[str, tuple[str, ...]] = {
         "air_date",
         "seen",
         "seen_date",
+        "is_special",
         "is_watched",
         "runtime",
     ),
@@ -224,6 +230,8 @@ CSV_FIELDS: dict[str, tuple[str, ...]] = {
         "followed_at",
         "last_watch_date",
         "filters",
+        "watched_episode_count",
+        "aired_episode_count",
         "created_at",
         "updated_at",
     ),
@@ -1001,6 +1009,41 @@ def _source_integrity(state: _State) -> None:
         _fail()
 
 
+def _validate_suite_tv_archive(path: Path) -> None:
+    payload = _read_bytes(path, maximum_bytes=MAXIMUM_REPORT_BYTES)
+    if not payload.startswith(b"PK\x03\x04"):
+        _fail()
+    try:
+        with zipfile.ZipFile(io.BytesIO(payload)) as archive:
+            entries = archive.infolist()
+            if tuple(entry.filename for entry in entries) != LIBERATOR_FILENAMES:
+                _fail()
+            total_uncompressed = 0
+            for entry in entries:
+                if (
+                    entry.is_dir()
+                    or "/" in entry.filename
+                    or "\\" in entry.filename
+                    or entry.flag_bits & 0x1
+                    or entry.compress_type not in {zipfile.ZIP_STORED, zipfile.ZIP_DEFLATED}
+                    or entry.file_size <= 0
+                    or entry.file_size > MAXIMUM_REPORT_BYTES
+                    or entry.compress_size <= 0
+                    or entry.compress_size > MAXIMUM_REPORT_BYTES
+                    or ((entry.external_attr >> 16) & 0o777) != EXPECTED_FILE_MODE
+                ):
+                    _fail()
+                total_uncompressed += entry.file_size
+                if total_uncompressed > MAXIMUM_REPORT_BYTES:
+                    _fail()
+            for entry in entries:
+                content = archive.read(entry)
+                if len(content) != entry.file_size:
+                    _fail()
+    except (OSError, RuntimeError, ValueError, zipfile.BadZipFile):
+        _fail()
+
+
 def _artifact_bindings(state: _State) -> None:
     pdf_status = state.recovery_state["pdf"]["status"]
     expected = list(_BOUND_ARTIFACTS)
@@ -1024,6 +1067,11 @@ def _artifact_bindings(state: _State) -> None:
         )
         if observed != binding:
             _fail()
+        if artifact_id in {
+            "suite_tv_liberator_confirmed",
+            "suite_tv_liberator_estimated_progress",
+        }:
+            _validate_suite_tv_archive(state.extraction / Path(relative_path))
     state.artifact_bindings = list(bindings)
 
 
@@ -1406,6 +1454,7 @@ def _expected_core_tables(
                         "air_date": item.get("air_date", ""),
                         "seen": item.get("seen", ""),
                         "seen_date": item.get("seen_date", ""),
+                        "is_special": item.get("is_special", ""),
                         "is_watched": item.get("is_watched", ""),
                         "runtime": item.get("runtime", ""),
                     }
@@ -1442,6 +1491,7 @@ def _expected_core_tables(
                     "uuid": item.get("uuid", ""),
                     "name": meta.get("name", ""),
                     "imdb_id": meta.get("imdb_id", ""),
+                    "tvdb_id": _external_source_id(meta, "tvdb"),
                     "first_release_date": meta.get("first_release_date", ""),
                     "library_status": "watched"
                     if watched_at
@@ -1452,11 +1502,18 @@ def _expected_core_tables(
                     "genres": " | ".join(str(value) for value in meta.get("genres") or []),
                     "filters": " | ".join(filters),
                     "is_watched": extended.get("is_watched", ""),
+                    "rewatch_count": item.get(
+                        "rewatch_count",
+                        extended.get("rewatch_count", ""),
+                    ),
                     "created_at": item.get("created_at", ""),
                     "updated_at": item.get("updated_at", ""),
                 }
             )
         elif item.get("entity_type") == "series":
+            watch_status = (
+                item.get("watch_status") if isinstance(item.get("watch_status"), dict) else {}
+            )
             series_library.append(
                 {
                     "uuid": item.get("uuid", ""),
@@ -1467,6 +1524,8 @@ def _expected_core_tables(
                     "followed_at": sorting_value(item, "follow_date"),
                     "last_watch_date": sorting_value(item, "watch_date", "watched_date"),
                     "filters": " | ".join(filters),
+                    "watched_episode_count": watch_status.get("watched_episode_count", ""),
+                    "aired_episode_count": watch_status.get("aired_episode_count", ""),
                     "created_at": item.get("created_at", ""),
                     "updated_at": item.get("updated_at", ""),
                 }

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -51,6 +51,7 @@ def synthetic_payloads() -> list[tuple[str, str, bytes, int]]:
                     "watched_at": "2025-01-02T03:04:05Z",
                     "created_at": "2025-01-01T00:00:00Z",
                     "updated_at": "2025-01-03T00:00:00Z",
+                    "rewatch_count": 2,
                     "sorting": [
                         {"id": "follow_date", "value": "2025-01-01T00:00:00Z"},
                         {"id": "watched_date", "value": "2025-01-02T03:04:05Z"},
@@ -62,6 +63,7 @@ def synthetic_payloads() -> list[tuple[str, str, bytes, int]]:
                         "first_release_date": "2024-06-01",
                         "runtime": 7200,
                         "genres": ["Drama", "Mystery"],
+                        "external_sources": [{"source": "tvdb", "id": "700001"}],
                         "poster_url": (
                             "https://cdn.example.invalid/posters/example.jpg"
                             "?token=SYNTHETIC_TOKEN#private"
@@ -96,6 +98,7 @@ def synthetic_payloads() -> list[tuple[str, str, bytes, int]]:
                         "first_release_date": "2026-01-01",
                         "runtime": 6000,
                         "genres": ["Comedy"],
+                        "external_sources": [{"source": "tvdb", "id": "700002"}],
                     },
                 },
                 {
@@ -108,8 +111,12 @@ def synthetic_payloads() -> list[tuple[str, str, bytes, int]]:
                         {"id": "follow_date", "value": "2024-01-01T00:00:00Z"},
                         {"id": "watch_date", "value": "2025-03-04T05:06:07Z"},
                     ],
+                    "watch_status": {
+                        "watched_episode_count": 1,
+                        "aired_episode_count": 2,
+                    },
                     "meta": {
-                        "id": "series-example-1",
+                        "id": "700101",
                         "name": "Example Series",
                         "country": "AU",
                         "is_ended": False,
@@ -124,7 +131,7 @@ def synthetic_payloads() -> list[tuple[str, str, bytes, int]]:
             "type": "list",
             "objects": [
                 {
-                    "uuid": "44444444-4444-4444-8444-444444444444",
+                    "uuid": MOVIE_UUID,
                     "id": "favorite-movie-example",
                     "name": "Favorite Example Movie",
                     "type": "movie",
@@ -139,7 +146,7 @@ def synthetic_payloads() -> list[tuple[str, str, bytes, int]]:
             "type": "list",
             "objects": [
                 {
-                    "uuid": "55555555-5555-4555-8555-555555555555",
+                    "uuid": SERIES_UUID,
                     "id": "favorite-series-example",
                     "name": "Favorite Example Series",
                     "type": "series",
@@ -173,14 +180,15 @@ def synthetic_payloads() -> list[tuple[str, str, bytes, int]]:
     episodes = {
         "data": [
             {
-                "id": "episode-example-1",
-                "show": {"id": "series-example-1", "name": "Example Series"},
+                "id": "700201",
+                "show": {"id": "700101", "name": "Example Series"},
                 "season_number": 1,
                 "number": 2,
                 "name": "The Synthetic Episode",
                 "air_date": "2025-03-01T00:00:00Z",
                 "seen": True,
                 "seen_date": "2025-03-04T05:06:07Z",
+                "is_special": False,
                 "is_watched": True,
                 "runtime": 2700,
             }

--- a/tests/test_analyze_report.py
+++ b/tests/test_analyze_report.py
@@ -290,6 +290,14 @@ class AnalyzeAndReportTests(unittest.TestCase):
 
             analysis = extraction / "analysis"
             self.assertFalse((analysis / "cache_responses").exists())
+            movies = {row["name"]: row for row in read_csv_rows(analysis / "movie_library.csv")}
+            self.assertEqual(movies["Example Movie"]["tvdb_id"], "700001")
+            self.assertEqual(movies["Example Movie"]["rewatch_count"], "2")
+            series = read_csv_rows(analysis / "series_library.csv")
+            self.assertEqual(series[0]["watched_episode_count"], "1")
+            self.assertEqual(series[0]["aired_episode_count"], "2")
+            episodes = read_csv_rows(analysis / "episode_cache_unique.csv")
+            self.assertEqual(episodes[0]["is_special"], "False")
             cache_index = read_csv_rows(analysis / "cache_index.csv")
             self.assertEqual(len(cache_index), 8)
             self.assertEqual(

--- a/tests/test_cancellation_and_reports.py
+++ b/tests/test_cancellation_and_reports.py
@@ -621,6 +621,8 @@ class CompletionContractTests(unittest.TestCase):
             "trailer_references",
             "media_url_inventory",
             "image_cache_references",
+            "suite_tv_liberator_confirmed",
+            "suite_tv_liberator_estimated_progress",
             "markdown_report",
             "html_report",
             "pdf_report",

--- a/tests/test_recovery_output_validator.py
+++ b/tests/test_recovery_output_validator.py
@@ -11,6 +11,7 @@ import sqlite3
 import subprocess
 import tempfile
 import unittest
+import zipfile
 from contextlib import closing
 from pathlib import Path
 from unittest import mock
@@ -43,6 +44,7 @@ from tvtime_extractor.errors import UnsafePathError
 from tvtime_extractor.extract import PRIMARY_DOMAIN
 from tvtime_extractor.report import build_report
 from tvtime_extractor.safety import write_json_private_atomic
+from tvtime_extractor.suite_tv import LIBERATOR_FILENAMES
 from tvtime_extractor.visual_report import HTML_REPORT_FILENAME, PDF_REPORT_FILENAME
 
 
@@ -131,6 +133,64 @@ class RecoveryOutputValidatorTests(unittest.TestCase):
         )
         self.assertEqual(dict(result.counts)["series_library"], 1)
         self.assertEqual(dict(result.counts)["saved_movies"], 1)
+
+    def test_suite_tv_archives_are_root_level_bound_and_tamper_evident(self) -> None:
+        output = self._copy_fixture()
+        analysis = output / "TVTime-Extraction" / "analysis"
+        _marker_path, marker = self._marker(output)
+        bindings = {
+            binding["id"]: binding for binding in marker["artifacts"] if isinstance(binding, dict)
+        }
+        expected = {
+            "suite_tv_liberator_confirmed": "Suite-TV-Liberator-confirmed.zip",
+            "suite_tv_liberator_estimated_progress": ("Suite-TV-Liberator-estimated-progress.zip"),
+        }
+        for artifact_id, filename in expected.items():
+            with self.subTest(artifact_id=artifact_id):
+                archive_path = analysis / filename
+                self.assertTrue(archive_path.is_file())
+                self.assertEqual(
+                    bindings[artifact_id]["relative_path"],
+                    f"analysis/{filename}",
+                )
+                with zipfile.ZipFile(archive_path) as archive:
+                    self.assertEqual(tuple(archive.namelist()), LIBERATOR_FILENAMES)
+                    self.assertTrue(all("/" not in name for name in archive.namelist()))
+
+        confirmed = analysis / expected["suite_tv_liberator_confirmed"]
+        with confirmed.open("ab") as handle:
+            handle.write(b"synthetic-tamper")
+        with self.assertRaises(ValidationFailure) as raised:
+            validate_recovery_output(output)
+        self.assertEqual(raised.exception.gate, "artifact_bindings")
+
+    def test_resealed_suite_tv_archive_with_wrong_members_is_rejected(self) -> None:
+        output = self._copy_fixture()
+        archive_path = (
+            output / "TVTime-Extraction" / "analysis" / "Suite-TV-Liberator-confirmed.zip"
+        )
+        with zipfile.ZipFile(
+            archive_path,
+            "w",
+            compression=zipfile.ZIP_DEFLATED,
+        ) as archive:
+            for name in LIBERATOR_FILENAMES[:-1]:
+                info = zipfile.ZipInfo(name)
+                info.create_system = 3
+                info.compress_type = zipfile.ZIP_DEFLATED
+                info.external_attr = 0o100600 << 16
+                archive.writestr(info, b"[]")
+        if os.name != "nt":
+            archive_path.chmod(0o600)
+        self._reseal_artifact(
+            output,
+            "suite_tv_liberator_confirmed",
+            archive_path,
+        )
+
+        with self.assertRaises(ValidationFailure) as raised:
+            validate_recovery_output(output)
+        self.assertEqual(raised.exception.gate, "artifact_bindings")
 
     def test_extra_output_root_member_fails_closed(self) -> None:
         output = self._copy_fixture()

--- a/tests/test_suite_tv.py
+++ b/tests/test_suite_tv.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+import stat
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from tvtime_extractor.suite_tv import (
+    LIBERATOR_FILENAMES,
+    build_liberator_files,
+    write_suite_tv_zip,
+)
+
+SERIES = [
+    {
+        "uuid": "30000000-0000-4000-8000-000000000001",
+        "series_id": "101",
+        "name": "Synthetic Suite Series",
+        "followed_at": "2020-01-01T00:00:00Z",
+        "created_at": "2020-01-01T00:00:00Z",
+        "watched_episode_count": "2",
+        "aired_episode_count": "3",
+    }
+]
+MOVIES = [
+    {
+        "uuid": "40000000-0000-4000-8000-000000000001",
+        "name": "Synthetic Suite Movie",
+        "tvdb_id": "501",
+        "imdb_id": "",
+        "created_at": "2020-02-01T00:00:00Z",
+        "is_watched": "True",
+        "watched_at": "2020-02-02T03:04:05Z",
+        "rewatch_count": "2",
+    },
+    {
+        "uuid": "40000000-0000-4000-8000-000000000002",
+        "name": "Synthetic Unknown-Date Movie",
+        "tvdb_id": "502",
+        "imdb_id": "tt0000502",
+        "created_at": "2020-02-03T00:00:00Z",
+        "is_watched": "True",
+        "watched_at": "",
+        "rewatch_count": "0",
+    },
+    {
+        "uuid": "40000000-0000-4000-8000-000000000003",
+        "name": "Synthetic Movie Without TVDB",
+        "tvdb_id": "",
+        "is_watched": "False",
+    },
+]
+EPISODES = [
+    {
+        "episode_id": "1000",
+        "show_id": "101",
+        "show_name": "Synthetic Suite Series",
+        "season": "0",
+        "episode": "1",
+        "is_special": "True",
+        "is_watched": "False",
+        "seen": "False",
+        "seen_date": "",
+    },
+    {
+        "episode_id": "1001",
+        "show_id": "101",
+        "show_name": "Synthetic Suite Series",
+        "season": "1",
+        "episode": "1",
+        "is_special": "False",
+        "is_watched": "False",
+        "seen": "False",
+        "seen_date": "",
+    },
+    {
+        "episode_id": "1002",
+        "show_id": "101",
+        "show_name": "Synthetic Suite Series",
+        "season": "1",
+        "episode": "2",
+        "is_special": "False",
+        "is_watched": "True",
+        "seen": "True",
+        "seen_date": "2020-03-02T01:02:03Z",
+    },
+    {
+        "episode_id": "1003",
+        "show_id": "101",
+        "show_name": "Synthetic Suite Series",
+        "season": "1",
+        "episode": "3",
+        "is_special": "False",
+        "is_watched": "False",
+        "seen": "False",
+        "seen_date": "",
+    },
+]
+FAVORITES = {
+    "movies": [
+        {
+            "uuid": "40000000-0000-4000-8000-000000000001",
+            "created_at": "2020-04-01T00:00:00Z",
+        }
+    ],
+    "shows": [
+        {
+            "uuid": "30000000-0000-4000-8000-000000000001",
+            "created_at": "2020-04-02T00:00:00Z",
+        }
+    ],
+}
+
+
+class SuiteTVLiberatorTests(unittest.TestCase):
+    def test_confirmed_files_match_liberator_schema(self) -> None:
+        files = build_liberator_files(
+            series=SERIES,
+            movies=MOVIES,
+            favorites=FAVORITES,
+            episodes=EPISODES,
+            estimate_progress=False,
+        )
+
+        self.assertEqual(tuple(files), LIBERATOR_FILENAMES)
+        shows = json.loads(files["shows.json"])
+        movies = json.loads(files["movies.json"])
+        favorites = json.loads(files["favorites.json"])
+        self.assertEqual(json.loads(files["lists.json"]), [])
+
+        self.assertEqual(
+            movies[0],
+            {
+                "id": {"tvdb": 501, "imdb": "-1"},
+                "uuid": "40000000-0000-4000-8000-000000000001",
+                "title": "Synthetic Suite Movie",
+                "created_at": "2020-02-01T00:00:00Z",
+                "rating": None,
+                "is_watched": True,
+                "rewatch_count": 2,
+                "watched_at": "2020-02-02T03:04:05Z",
+            },
+        )
+        self.assertEqual(movies[1]["id"], {"tvdb": 502, "imdb": "tt0000502"})
+        self.assertNotIn("watched_at", movies[1])
+        self.assertEqual(len(movies), 2)
+
+        self.assertEqual(shows[0]["id"], {"tvdb": 101, "imdb": "-1"})
+        self.assertEqual(shows[0]["status"], "continuing")
+        episodes = {
+            episode["id"]["tvdb"]: episode
+            for season in shows[0]["seasons"]
+            for episode in season["episodes"]
+        }
+        self.assertFalse(episodes[1000]["is_watched"])
+        self.assertFalse(episodes[1001]["is_watched"])
+        self.assertTrue(episodes[1002]["is_watched"])
+        self.assertEqual(episodes[1002]["watched_at"], "2020-03-02T01:02:03Z")
+        self.assertFalse(episodes[1003]["is_watched"])
+
+        self.assertEqual(favorites["name"], "Favorites")
+        self.assertEqual(
+            favorites["movies"],
+            [
+                {
+                    "id": {"tvdb": 501, "imdb": "-1"},
+                    "uuid": "40000000-0000-4000-8000-000000000001",
+                    "title": "Synthetic Suite Movie",
+                    "created_at": "2020-02-01T00:00:00Z",
+                    "rating": None,
+                    "added_at": "2020-04-01T00:00:00Z",
+                }
+            ],
+        )
+        self.assertNotIn("is_watched", favorites["movies"][0])
+        self.assertEqual(favorites["shows"][0]["added_at"], "2020-04-02T00:00:00Z")
+        self.assertNotIn("status", favorites["shows"][0])
+
+        activity = files["activity_history.csv"].decode("utf-8")
+        self.assertIn("\r\n", activity)
+        rows = list(csv.DictReader(io.StringIO(activity)))
+        self.assertEqual([row["type"] for row in rows], ["movie", "movie", "episode", "show"])
+        self.assertEqual(rows[0]["is_watched"], "true")
+        self.assertEqual(rows[0]["is_watchlisted"], "false")
+        self.assertEqual(rows[1]["is_watched"], "true")
+        self.assertEqual(rows[1]["is_watchlisted"], "true")
+        self.assertEqual(rows[2]["is_special"], "false")
+
+    def test_estimated_progress_retains_exact_watches_and_never_marks_specials(self) -> None:
+        files = build_liberator_files(
+            series=SERIES,
+            movies=MOVIES,
+            favorites=FAVORITES,
+            episodes=EPISODES,
+            estimate_progress=True,
+        )
+
+        shows = json.loads(files["shows.json"])
+        episodes = {
+            episode["id"]["tvdb"]: episode
+            for season in shows[0]["seasons"]
+            for episode in season["episodes"]
+        }
+        self.assertFalse(episodes[1000]["is_watched"])
+        self.assertTrue(episodes[1001]["is_watched"])
+        self.assertNotIn("watched_at", episodes[1001])
+        self.assertTrue(episodes[1002]["is_watched"])
+        self.assertEqual(episodes[1002]["watched_at"], "2020-03-02T01:02:03Z")
+        self.assertFalse(episodes[1003]["is_watched"])
+
+    def test_zip_has_exact_root_members_and_private_permissions(self) -> None:
+        files = build_liberator_files(
+            series=SERIES,
+            movies=MOVIES,
+            favorites=FAVORITES,
+            episodes=EPISODES,
+            estimate_progress=False,
+        )
+        with tempfile.TemporaryDirectory() as temporary:
+            archive_path = Path(temporary) / "Suite-TV-Liberator-confirmed.zip"
+
+            write_suite_tv_zip(archive_path, files)
+
+            self.assertEqual(stat.S_IMODE(archive_path.stat().st_mode), 0o600)
+            with zipfile.ZipFile(archive_path) as archive:
+                self.assertEqual(tuple(archive.namelist()), LIBERATOR_FILENAMES)
+                self.assertTrue(all("/" not in name for name in archive.namelist()))
+                self.assertTrue(
+                    all((info.external_attr >> 16) & 0o777 == 0o600 for info in archive.infolist())
+                )
+                self.assertEqual(
+                    {name: archive.read(name) for name in archive.namelist()},
+                    files,
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tvtime_extractor/analyze.py
+++ b/tvtime_extractor/analyze.py
@@ -711,6 +711,21 @@ def _integer(value: object) -> int:
         return 0
 
 
+def _external_source_id(meta: Mapping[str, object], source_name: str) -> str:
+    sources = meta.get("external_sources")
+    if not isinstance(sources, list):
+        return ""
+    for source in sources:
+        if not isinstance(source, dict):
+            continue
+        if str(source.get("source") or "").casefold() != source_name.casefold():
+            continue
+        external_id = _integer(source.get("id"))
+        if external_id > 0:
+            return str(external_id)
+    return ""
+
+
 def unique_favorites(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
     selected: dict[tuple[str, ...], dict[str, Any]] = {}
     for item in items:
@@ -1077,6 +1092,7 @@ def _analyze_extraction(
                         "air_date": item.get("air_date", ""),
                         "seen": item.get("seen", ""),
                         "seen_date": item.get("seen_date", ""),
+                        "is_special": item.get("is_special", ""),
                         "is_watched": item.get("is_watched", ""),
                         "runtime": item.get("runtime", ""),
                     }
@@ -1113,6 +1129,7 @@ def _analyze_extraction(
                     "uuid": item.get("uuid", ""),
                     "name": meta.get("name", ""),
                     "imdb_id": meta.get("imdb_id", ""),
+                    "tvdb_id": _external_source_id(meta, "tvdb"),
                     "first_release_date": meta.get("first_release_date", ""),
                     "library_status": "watched"
                     if watched_at
@@ -1123,11 +1140,18 @@ def _analyze_extraction(
                     "genres": " | ".join(str(value) for value in meta.get("genres") or []),
                     "filters": " | ".join(filters),
                     "is_watched": extended.get("is_watched", ""),
+                    "rewatch_count": item.get(
+                        "rewatch_count",
+                        extended.get("rewatch_count", ""),
+                    ),
                     "created_at": item.get("created_at", ""),
                     "updated_at": item.get("updated_at", ""),
                 }
             )
         elif item.get("entity_type") == "series":
+            watch_status = (
+                item.get("watch_status") if isinstance(item.get("watch_status"), dict) else {}
+            )
             series_library.append(
                 {
                     "uuid": item.get("uuid", ""),
@@ -1138,6 +1162,8 @@ def _analyze_extraction(
                     "followed_at": sorting_value(item, "follow_date"),
                     "last_watch_date": sorting_value(item, "watch_date", "watched_date"),
                     "filters": " | ".join(filters),
+                    "watched_episode_count": watch_status.get("watched_episode_count", ""),
+                    "aired_episode_count": watch_status.get("aired_episode_count", ""),
                     "created_at": item.get("created_at", ""),
                     "updated_at": item.get("updated_at", ""),
                 }
@@ -1170,6 +1196,7 @@ def _analyze_extraction(
         "uuid",
         "name",
         "imdb_id",
+        "tvdb_id",
         "first_release_date",
         "library_status",
         "watched_at",
@@ -1178,6 +1205,7 @@ def _analyze_extraction(
         "genres",
         "filters",
         "is_watched",
+        "rewatch_count",
         "created_at",
         "updated_at",
     ]
@@ -1208,6 +1236,8 @@ def _analyze_extraction(
             "followed_at",
             "last_watch_date",
             "filters",
+            "watched_episode_count",
+            "aired_episode_count",
             "created_at",
             "updated_at",
         ],
@@ -1237,6 +1267,7 @@ def _analyze_extraction(
         "air_date",
         "seen",
         "seen_date",
+        "is_special",
         "is_watched",
         "runtime",
     ]

--- a/tvtime_extractor/report.py
+++ b/tvtime_extractor/report.py
@@ -80,6 +80,7 @@ from .safety import (
     write_json_private_atomic,
     write_text_private,
 )
+from .suite_tv import build_liberator_files, write_suite_tv_zip
 from .visual_report import (
     HTML_REPORT_FILENAME,
     PDF_REPORT_FILENAME,
@@ -213,6 +214,11 @@ _BOUND_ARTIFACTS: tuple[tuple[str, str], ...] = (
     ("trailer_references", "analysis/trailer_references.csv"),
     ("media_url_inventory", "analysis/media_url_inventory.csv"),
     ("image_cache_references", "analysis/image_cache_references.csv"),
+    ("suite_tv_liberator_confirmed", "analysis/Suite-TV-Liberator-confirmed.zip"),
+    (
+        "suite_tv_liberator_estimated_progress",
+        "analysis/Suite-TV-Liberator-estimated-progress.zip",
+    ),
     ("markdown_report", "analysis/TVTime-Recovered-Data.md"),
     ("html_report", f"analysis/{HTML_REPORT_FILENAME}"),
 )
@@ -262,6 +268,7 @@ _PRE_REPORT_CSV_FIELDS: dict[str, tuple[str, ...]] = {
         "uuid",
         "name",
         "imdb_id",
+        "tvdb_id",
         "first_release_date",
         "library_status",
         "watched_at",
@@ -270,6 +277,7 @@ _PRE_REPORT_CSV_FIELDS: dict[str, tuple[str, ...]] = {
         "genres",
         "filters",
         "is_watched",
+        "rewatch_count",
         "created_at",
         "updated_at",
     ),
@@ -293,6 +301,7 @@ _PRE_REPORT_CSV_FIELDS: dict[str, tuple[str, ...]] = {
         "air_date",
         "seen",
         "seen_date",
+        "is_special",
         "is_watched",
         "runtime",
     ),
@@ -307,6 +316,8 @@ _PRE_REPORT_CSV_FIELDS: dict[str, tuple[str, ...]] = {
         "followed_at",
         "last_watch_date",
         "filters",
+        "watched_episode_count",
+        "aired_episode_count",
         "created_at",
         "updated_at",
     ),
@@ -314,6 +325,7 @@ _PRE_REPORT_CSV_FIELDS: dict[str, tuple[str, ...]] = {
         "uuid",
         "name",
         "imdb_id",
+        "tvdb_id",
         "first_release_date",
         "library_status",
         "watched_at",
@@ -322,6 +334,7 @@ _PRE_REPORT_CSV_FIELDS: dict[str, tuple[str, ...]] = {
         "genres",
         "filters",
         "is_watched",
+        "rewatch_count",
         "created_at",
         "updated_at",
     ),
@@ -329,6 +342,7 @@ _PRE_REPORT_CSV_FIELDS: dict[str, tuple[str, ...]] = {
         "uuid",
         "name",
         "imdb_id",
+        "tvdb_id",
         "first_release_date",
         "library_status",
         "watched_at",
@@ -337,6 +351,7 @@ _PRE_REPORT_CSV_FIELDS: dict[str, tuple[str, ...]] = {
         "genres",
         "filters",
         "is_watched",
+        "rewatch_count",
         "created_at",
         "updated_at",
     ),
@@ -375,6 +390,7 @@ _PRE_REPORT_CSV_FIELDS: dict[str, tuple[str, ...]] = {
         "air_date",
         "seen",
         "seen_date",
+        "is_special",
         "is_watched",
         "runtime",
     ),
@@ -1700,6 +1716,8 @@ def _build_report(
         "trailer_references.csv",
         "media_url_inventory.csv",
         "image_cache_references.csv",
+        "Suite-TV-Liberator-confirmed.zip",
+        "Suite-TV-Liberator-estimated-progress.zip",
         "TVTime-Recovered-Data.md",
         HTML_REPORT_FILENAME,
         PDF_REPORT_FILENAME,
@@ -1765,6 +1783,33 @@ def _build_report(
     favorite_movies = read_analysis_csv("favorite_movies.csv")
     episodes = read_analysis_csv("episode_cache_unique.csv")
     watch_events = read_analysis_csv("watch_events_named.csv")
+    suite_tv_inputs = {
+        "series": series,
+        "movies": [*watched_movies, *movie_watchlist],
+        "favorites": {
+            "shows": favorite_shows,
+            "movies": favorite_movies,
+        },
+        "episodes": episodes,
+    }
+    confirmed_suite_tv = analysis / "Suite-TV-Liberator-confirmed.zip"
+    estimated_suite_tv = analysis / "Suite-TV-Liberator-estimated-progress.zip"
+    write_suite_tv_zip(
+        confirmed_suite_tv,
+        build_liberator_files(
+            **suite_tv_inputs,
+            estimate_progress=False,
+        ),
+    )
+    write_suite_tv_zip(
+        estimated_suite_tv,
+        build_liberator_files(
+            **suite_tv_inputs,
+            estimate_progress=True,
+        ),
+    )
+    _validate_report_artifact(confirmed_suite_tv, label="confirmed Suite TV archive")
+    _validate_report_artifact(estimated_suite_tv, label="estimated Suite TV archive")
     try:
         inventory_path = safe_join(extraction, "metadata", "inventory.csv")
     except ValueError as exc:

--- a/tvtime_extractor/suite_tv.py
+++ b/tvtime_extractor/suite_tv.py
@@ -1,0 +1,371 @@
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+import stat
+import zipfile
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+LIBERATOR_FILENAMES = (
+    "shows.json",
+    "movies.json",
+    "favorites.json",
+    "lists.json",
+    "activity_history.csv",
+)
+
+_ACTIVITY_HEADER = (
+    "imdb_id",
+    "tvdb_id",
+    "type",
+    "title",
+    "season",
+    "episode",
+    "is_special",
+    "is_watched",
+    "watched_at",
+    "status",
+    "is_watchlisted",
+    "rating",
+)
+
+
+def _text(row: Mapping[str, object], *keys: str) -> str:
+    for key in keys:
+        value = row.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return ""
+
+
+def _integer(value: object, default: int = 0) -> int:
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return default
+
+
+def _boolean(value: object) -> bool:
+    return str(value).strip().casefold() in {"1", "true", "yes"}
+
+
+def _csv_boolean(value: bool) -> str:
+    return "true" if value else "false"
+
+
+def _show_status(row: Mapping[str, object]) -> str:
+    watched = _integer(row.get("watched_episode_count"))
+    aired = _integer(row.get("aired_episode_count"))
+    if watched <= 0:
+        return "not_started_yet"
+    if aired > 0 and watched >= aired:
+        return "up_to_date"
+    return "continuing"
+
+
+def _build_movies(rows: Iterable[Mapping[str, object]]) -> list[dict[str, Any]]:
+    movies: list[dict[str, Any]] = []
+    for row in rows:
+        tvdb_id = _integer(row.get("tvdb_id"))
+        if tvdb_id <= 0:
+            continue
+        movie: dict[str, Any] = {
+            "id": {
+                "tvdb": tvdb_id,
+                "imdb": _text(row, "imdb_id") or "-1",
+            },
+            "uuid": _text(row, "uuid", "movie_id"),
+            "title": _text(row, "name", "title"),
+            "created_at": _text(
+                row,
+                "created_at",
+                "record_created_at",
+                "followed_at",
+                "observed_at_utc",
+            ),
+            "rating": None,
+            "is_watched": _boolean(row.get("is_watched")),
+            "rewatch_count": _integer(row.get("rewatch_count")),
+        }
+        watched_at = _text(row, "watched_at")
+        if watched_at and not watched_at.startswith("0001-01-01"):
+            movie["watched_at"] = watched_at
+        movies.append(movie)
+    return movies
+
+
+def _build_shows(
+    series_rows: Iterable[Mapping[str, object]],
+    episode_rows: Iterable[Mapping[str, object]],
+    *,
+    estimate_progress: bool,
+) -> list[dict[str, Any]]:
+    episodes_by_show: dict[int, list[Mapping[str, object]]] = {}
+    for episode in episode_rows:
+        show_id = _integer(episode.get("show_id"))
+        episode_id = _integer(episode.get("episode_id"))
+        if show_id > 0 and episode_id > 0:
+            episodes_by_show.setdefault(show_id, []).append(episode)
+
+    shows: list[dict[str, Any]] = []
+    for row in series_rows:
+        tvdb_id = _integer(row.get("series_id") or row.get("show_id"))
+        source_episodes = episodes_by_show.get(tvdb_id, [])
+        seasons: dict[int, list[dict[str, Any]]] = {}
+        exact_regular_watches = 0
+        for source in sorted(
+            source_episodes,
+            key=lambda episode: (
+                _integer(episode.get("season")),
+                _integer(episode.get("episode")),
+                _integer(episode.get("episode_id")),
+            ),
+        ):
+            is_special = _boolean(source.get("is_special"))
+            is_watched = _boolean(source.get("is_watched")) or _boolean(source.get("seen"))
+            if is_watched and not is_special:
+                exact_regular_watches += 1
+            episode: dict[str, Any] = {
+                "number": _integer(source.get("episode")),
+                "special": is_special,
+                "id": {
+                    "tvdb": _integer(source.get("episode_id")),
+                    "imdb": "-1",
+                },
+                "rating": None,
+                "is_watched": is_watched,
+            }
+            watched_at = _text(source, "watched_at", "seen_date")
+            if is_watched and watched_at and not watched_at.startswith("0001-01-01"):
+                episode["watched_at"] = watched_at
+            seasons.setdefault(_integer(source.get("season")), []).append(episode)
+
+        if estimate_progress:
+            remaining = max(
+                0,
+                _integer(row.get("watched_episode_count")) - exact_regular_watches,
+            )
+            for season_number in sorted(seasons):
+                for episode in seasons[season_number]:
+                    if remaining <= 0:
+                        break
+                    if episode["special"] or episode["is_watched"]:
+                        continue
+                    episode["is_watched"] = True
+                    remaining -= 1
+
+        title = _text(row, "name", "title")
+        if not title and source_episodes:
+            title = _text(source_episodes[0], "show_name")
+        shows.append(
+            {
+                "id": {
+                    "tvdb": tvdb_id,
+                    "imdb": _text(row, "imdb_id") or "-1",
+                },
+                "uuid": _text(row, "uuid") or f"legacy-tvdb-{tvdb_id}",
+                "title": title,
+                "status": _show_status(row),
+                "seasons": [
+                    {"number": number, "episodes": seasons[number]} for number in sorted(seasons)
+                ],
+                "created_at": _text(
+                    row,
+                    "created_at",
+                    "followed_at",
+                    "record_created_at",
+                    "observed_at_utc",
+                ),
+            }
+        )
+    return shows
+
+
+def _build_favorites(
+    favorite_rows: Mapping[str, Iterable[Mapping[str, object]]],
+    *,
+    shows: Iterable[Mapping[str, Any]],
+    movies: Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    movies_by_uuid = {str(movie["uuid"]): movie for movie in movies}
+    shows_by_uuid = {str(show["uuid"]): show for show in shows}
+
+    favorite_movies: list[dict[str, Any]] = []
+    for favorite in favorite_rows.get("movies", ()):
+        movie = movies_by_uuid.get(_text(favorite, "uuid", "movie_id"))
+        if movie is None:
+            continue
+        favorite_movies.append(
+            {
+                "id": movie["id"],
+                "uuid": movie["uuid"],
+                "title": movie["title"],
+                "created_at": movie["created_at"],
+                "rating": movie["rating"],
+                "added_at": _text(favorite, "added_at", "created_at") or movie["created_at"],
+            }
+        )
+
+    favorite_shows: list[dict[str, Any]] = []
+    for favorite in favorite_rows.get("shows", ()):
+        show = shows_by_uuid.get(_text(favorite, "uuid", "series_id", "show_id"))
+        if show is None:
+            continue
+        favorite_shows.append(
+            {
+                "id": show["id"],
+                "uuid": show["uuid"],
+                "title": show["title"],
+                "seasons": show["seasons"],
+                "created_at": show["created_at"],
+                "added_at": _text(favorite, "added_at", "created_at") or show["created_at"],
+            }
+        )
+
+    return {
+        "name": "Favorites",
+        "description": "Your favorite movies and shows.",
+        "is_public": True,
+        "movies": favorite_movies,
+        "shows": favorite_shows,
+    }
+
+
+def _activity_csv(
+    shows: Iterable[Mapping[str, Any]],
+    movies: Iterable[Mapping[str, Any]],
+) -> bytes:
+    output = io.StringIO(newline="")
+    writer = csv.writer(output, lineterminator="\r\n")
+    writer.writerow(_ACTIVITY_HEADER)
+    for movie in movies:
+        watched_at = str(movie.get("watched_at") or "")
+        writer.writerow(
+            (
+                movie["id"]["imdb"],
+                movie["id"]["tvdb"],
+                "movie",
+                movie["title"],
+                "",
+                "",
+                "false",
+                _csv_boolean(bool(movie["is_watched"])),
+                watched_at,
+                "",
+                _csv_boolean(not bool(watched_at)),
+                "",
+            )
+        )
+    for show in shows:
+        for season in show["seasons"]:
+            for episode in season["episodes"]:
+                if not episode["is_watched"]:
+                    continue
+                watched_at = str(episode.get("watched_at") or "")
+                writer.writerow(
+                    (
+                        episode["id"]["imdb"],
+                        episode["id"]["tvdb"],
+                        "episode",
+                        show["title"],
+                        season["number"],
+                        episode["number"],
+                        _csv_boolean(bool(episode["special"])),
+                        "true",
+                        watched_at,
+                        show["status"],
+                        _csv_boolean(not bool(watched_at)),
+                        "",
+                    )
+                )
+    for show in shows:
+        has_unwatched = any(
+            not episode["is_watched"]
+            for season in show["seasons"]
+            for episode in season["episodes"]
+        )
+        writer.writerow(
+            (
+                show["id"]["imdb"],
+                show["id"]["tvdb"],
+                "show",
+                show["title"],
+                "",
+                "",
+                "",
+                "",
+                "",
+                show["status"],
+                _csv_boolean(has_unwatched),
+                "",
+            )
+        )
+    return output.getvalue().encode("utf-8")
+
+
+def _json_bytes(value: object) -> bytes:
+    return json.dumps(value, ensure_ascii=False, indent=2).encode("utf-8")
+
+
+def build_liberator_files(
+    *,
+    series: Iterable[Mapping[str, object]],
+    movies: Iterable[Mapping[str, object]],
+    favorites: Mapping[str, Iterable[Mapping[str, object]]],
+    episodes: Iterable[Mapping[str, object]],
+    estimate_progress: bool,
+) -> dict[str, bytes]:
+    movie_values = _build_movies(movies)
+    show_values = _build_shows(
+        series,
+        episodes,
+        estimate_progress=estimate_progress,
+    )
+    favorite_values = _build_favorites(
+        favorites,
+        shows=show_values,
+        movies=movie_values,
+    )
+    return {
+        "shows.json": _json_bytes(show_values),
+        "movies.json": _json_bytes(movie_values),
+        "favorites.json": _json_bytes(favorite_values),
+        "lists.json": _json_bytes([]),
+        "activity_history.csv": _activity_csv(show_values, movie_values),
+    }
+
+
+def write_suite_tv_zip(path: Path, files: Mapping[str, bytes]) -> None:
+    if tuple(files) != LIBERATOR_FILENAMES:
+        raise ValueError("Suite TV export files do not match the Liberator schema")
+
+    descriptor = os.open(
+        path,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_CLOEXEC", 0),
+        0o600,
+    )
+    try:
+        if hasattr(os, "fchmod"):
+            os.fchmod(descriptor, 0o600)
+        else:
+            os.chmod(path, 0o600)
+        with os.fdopen(descriptor, "wb") as output:
+            descriptor = -1
+            with zipfile.ZipFile(
+                output,
+                "w",
+                compression=zipfile.ZIP_DEFLATED,
+            ) as archive:
+                for name in LIBERATOR_FILENAMES:
+                    info = zipfile.ZipInfo(name)
+                    info.create_system = 3
+                    info.compress_type = zipfile.ZIP_DEFLATED
+                    info.external_attr = (stat.S_IFREG | 0o600) << 16
+                    archive.writestr(info, files[name])
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)


### PR DESCRIPTION
## Summary

- add `Suite-TV-Liberator-confirmed.zip` with only directly recovered watch state
- add `Suite-TV-Liberator-estimated-progress.zip`, which preserves exact watches and fills only the oldest unwatched regular episodes up to a recovered aggregate count
- preserve recovered TVDB IDs, movie rewatch counts, series progress counts, and episode special flags in the normalized tables used to build the exports
- seal both archives into `recovery_state.json` and validate them in both Python and the native macOS app

## Why

Suite TV accepts the five-file TV Time Liberator ZIP layout rather than this extractor's Markdown, HTML, PDF, or normalized CSV report set. These exports provide that import path without network lookups or an online conversion service.

Each ZIP contains exactly:

- `shows.json`
- `movies.json`
- `favorites.json`
- `lists.json`
- `activity_history.csv`

The confirmed archive remains exact. The estimated archive is explicitly bounded: it never estimates specials, retains every exact recovered watch, and cannot infer skipped, out-of-order, or repeated episode choices. Movies without a recovered positive TVDB ID are omitted because Suite TV cannot identify them safely.

ZIP files and members are owner-only on POSIX. Archive names, membership, compression, sizes, modes, hashes, and completion bindings are validated before a recovery package is accepted.

## Validation

- `python -m ruff check .`
- `python -m ruff format --check .`
- Python: 266 tests passed, 1 Windows-only test skipped
- `xcrun swift-format lint --strict --recursive ...`
- Swift debug: 113/113 tests passed
- Swift release: 113/113 tests passed
- Swift release build passed
- shell syntax checks passed
- `git diff --check`
- wheel and sdist built from the exact commit; source, tree, membership, content, metadata, and privacy verification passed

The checkout is under `~/Documents`, which the existing destination-safety logic classifies as cloud or shared storage and causes three unrelated local-path tests to fail there. Running the same source from a private local directory under `~/Library/Application Support` makes the complete debug and release suites pass. Tests and documentation use synthetic data only.
