### PR TITLE
Add privacy-safe recovery troubleshooting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,12 @@ All notable changes are documented here. The project follows semantic versioning
 
 ## Unreleased prerelease candidate: v0.3.0-alpha.1
 
-This is the planned first alpha for the 0.3.0 cross-platform work. It remains unpublished:
-successful synthetic checks do not replace the required Windows device, UI, packaging, and
-source-bound release validation.
+This is the planned first alpha for the 0.3.0 cross-platform work. It remains unpublished.
+Successful synthetic checks do not make every device route verified, and the public alpha artifact
+set deliberately excludes a Windows binary.
 
 See the [v0.3.0-alpha.1 release preparation record](docs/release-v0.3.0-alpha.1.md) for completed
-evidence and remaining native gates.
+evidence, release gates, and remaining native proof.
 
 - Added native source-neutral recovery for legacy Android backup containers, preserved Android
   database snapshots, and official TV Time export ZIP/CSV files. These lanes reuse the normalized
@@ -26,6 +26,8 @@ evidence and remaining native gates.
   and private-folder result actions without persisting source or output paths.
 - Added native macOS source selection for Android and official exports while preserving the
   published v0.2.0 encrypted-iOS-backup workflow.
+- Added a copyable, bounded Safe Diagnostics trail to the macOS failure screen. It reports only
+  fixed operation, milestone, and failure codes and does not include raw errors or private values.
 - Added privacy-safe Android capability probing and explicitly acknowledged legacy-device capture.
   Modern release apps, disabled backup policy, multiple devices, and unauthorized devices fail
   closed.
@@ -53,8 +55,9 @@ evidence and remaining native gates.
   still requires a synthetic Windows UI smoke test before it is considered release-ready.
 - Preserved recovered TVDB IDs, rewatch counts, aggregate series progress, and episode-special flags
   in normalized tables.
-- This prerelease candidate has not been tagged, uploaded, or published. v0.2.0 remains the current
-  stable release.
+- This prerelease candidate has not been tagged, uploaded, or published. Its intended public assets
+  are signed/notarized Apple silicon and Intel DMGs plus verified Python wheel/source packages; no
+  MSIX is included. v0.2.0 remains the current stable release.
 
 ## 0.2.0 - 2026-07-20
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ backup, contact TV Time, restore data to the app, or provide an official cloud-a
 > v0.2.0.
 
 The [v0.3.0-alpha.1 release preparation record](docs/release-v0.3.0-alpha.1.md) tracks completed
-evidence and the native checks still required before publication.
+evidence, the intentionally limited public artifact set, and the remaining alpha release gates.
 
 This project is independent and is not affiliated with or endorsed by TV Time or Apple. TV Time and
 related marks belong to their respective owners. Use it only with data you own or are authorized to
@@ -42,14 +42,17 @@ Download it from the [official v0.2.0 release](https://github.com/amirbrooks/tvt
 See the [macOS guide](docs/macos.md) for installation and the
 [v0.2.0 release record](docs/release-v0.2.0.md) for the completed distribution gates.
 
-## What every recovery needs
+## What recovery needs
 
-- A **completed and encrypted** local iOS or iPadOS backup made with Finder, Apple Devices, or
-  iTunes
-- The encryption password for that backup
-- The phone safely ejected and disconnected after backup completion is confirmed
-- Enough free local space for manifest processing, the selected TV Time app data, and reports.
-  Recovery does not duplicate the whole device backup.
+Every route needs an owner-controlled local source, private local output storage, and enough free
+space for processing and reports.
+
+Encrypted iOS or iPadOS recovery also needs a completed encrypted local backup made with Finder,
+Apple Devices, or iTunes, its encryption password, and the phone safely ejected and disconnected
+after backup completion is confirmed. Recovery does not duplicate the whole device backup.
+
+Android and official-export routes use their own selected local source. They do not require an iOS
+backup or its password.
 
 Rooting a phone, bypassing Android backup policy, cloud-account scraping, and restoring recovered
 data to TV Time are not supported. Modern Android release apps commonly disable legacy backup; the
@@ -246,12 +249,20 @@ volumes, symbolic links, Windows reparse points, and cloud-hydrated placeholders
 source inspection. On Windows, the source must also be on private local NTFS storage so file
 identity checks remain trustworthy; copy an owner-controlled source there before recovery.
 
-The CLI commands are:
+The encrypted-iOS and core processing commands are:
 
 - `recover`: preflight, extract, analyze, and report in one workflow
 - `extract`: copy and inventory matching TV Time app-domain files only
 - `analyze`: build normalized private tables from one complete extraction
 - `report`: build readable and visual reports from one complete analysis
+
+The experimental Android and official-export commands are:
+
+- `recover-android-backup`: recover a compatible legacy Android backup container
+- `recover-android-snapshot`: recover an already-preserved Android database snapshot
+- `recover-export`: recover a supported official TV Time ZIP or CSV export
+- `android-probe`: report privacy-safe legacy backup capability
+- `android-capture`: explicitly capture a supported legacy Android backup
 
 Run `python -m tvtime_extractor <command> --help` through the virtual environment for exact options.
 `--debug` deliberately retains chained third-party exceptions and can expose backup paths,

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -130,10 +130,15 @@ password, free-form helper message, or report content. Unknown errors become
 `unrecognized_failure` instead of being stringified. The operating system controls unified-log
 retention.
 
-For support, prefer the safe reference code displayed by the app and a manual description of the
-stage. Do not export or upload a complete unified-log archive: unrelated processes can place private
-data in the same archive. Contributors can filter this app's bounded events locally as described in
-the troubleshooting guide.
+When recovery stops, the app shows the recent fixed-vocabulary events and can copy them as **Safe
+Diagnostics**. This short report contains the same bounded operation, milestone, and failure codes.
+It has no raw error text, timestamp, path, identifier, recovered value, or event count.
+
+For support, prefer this copied report, the displayed reference code, and a manual description of
+the stage. Review the text before sharing it. Do not send a screenshot of the recovery or results
+screen, and do not export or upload a complete unified-log archive: unrelated processes can place
+private data in the same archive. Contributors can filter this app's bounded events locally as
+described in the troubleshooting guide.
 
 Prefer the application or CLI version, operating system, Mac architecture when relevant, command or
 workflow stage, exit code, and a manually paraphrased error. Replace usernames, paths, IDs, titles,

--- a/docs/release-notes-v0.3.0-alpha.1.md
+++ b/docs/release-notes-v0.3.0-alpha.1.md
@@ -1,0 +1,43 @@
+# TV Time Backup Extractor v0.3.0-alpha.1
+
+This is an experimental GitHub prerelease for technical testers. It is not the latest stable
+release; v0.2.0 remains the stable recommendation.
+
+## Downloads
+
+- `TV-Time-Backup-Extractor-0.3.0-alpha.1-macOS-Apple-Silicon-arm64.dmg` for Apple silicon Macs
+- `TV-Time-Backup-Extractor-0.3.0-alpha.1-macOS-Intel-x86_64.dmg` for Intel Macs
+- the Python wheel or source package for Python 3.10 through 3.13 on macOS or Linux, and for the
+  documented existing-extraction/report routes on Windows
+- `SHA256SUMS` and the release manifests for verification
+
+The Mac DMGs are intended to be Developer ID signed, notarized, stapled, and Gatekeeper accepted.
+Verify the downloaded filenames against `SHA256SUMS` before opening them.
+
+## What is experimental
+
+The alpha adds macOS and Python recovery from official TV Time ZIP/CSV exports, compatible legacy
+Android backup containers, and preserved Android database snapshots. Android acquisition is device
+and schema dependent: modern devices commonly do not expose compatible app data, and unsupported
+sources fail closed.
+
+The repository contains a promising native Windows app candidate, but this release deliberately
+includes no MSIX or other Windows binary. Native Windows installation, UI behavior, real NTFS
+capability behavior, and complete packaged recovery are not yet proven. Advanced Windows testers
+may use the Python CLI or follow the private source-build instructions in `docs/windows.md` using
+only synthetic or owner-authorized local data.
+
+Existing encrypted-iOS recovery on macOS retains the published v0.2 workflow. Official-export
+recovery has synthetic end-to-end coverage. No test result claims that every TV Time app version,
+backup schema, or physical device is compatible.
+
+## Privacy and safety
+
+Recovery is local and offline. Never upload a backup, database, export, report, screenshot, marker,
+or recovered content to an issue. Keep every source read-only and retain recovered output only in
+private owner-controlled local storage. For encrypted-iOS recovery, use a completed encrypted
+backup and disconnect the phone after confirming that backup has finished. Opening a report can add
+its private filename to browser or viewer history and Recent Items.
+
+This project is independent and is not affiliated with or endorsed by TV Time, Apple, Google, or
+Microsoft.

--- a/docs/release-v0.3.0-alpha.1.md
+++ b/docs/release-v0.3.0-alpha.1.md
@@ -11,30 +11,39 @@ exists yet.
   `0.3.0a1` for Python, `0.3.0` plus bundle build `1` and the explicit
   `TVTimeReleaseVersion=0.3.0-alpha.1` for macOS, and private MSIX identity `0.3.0.1` with an Alpha
   display name for Windows. Artifact filenames use `0.3.0-alpha.1`. A later stable build must use
-  new filenames and increment the native package or bundle identifiers.
-- Tagging, uploading, and publication remain blocked until every gate in this record passes on one
-  frozen source commit.
+  new filenames and increment the native build and package version numbers without changing stable
+  application identifiers.
+- Tagging and uploading remain blocked until every pre-tag gate in this record passes on one frozen
+  source commit. Publication remains blocked until the uploaded draft assets pass revalidation.
 
 ## Alpha scope
 
 The candidate adds local recovery from supported legacy Android backups, preserved Android
-database snapshots, and official TV Time exports. It also adds a private x64 Windows app candidate
-for Android and export recovery on Windows 10 1809 or later, plus encrypted iOS backup recovery on
-Windows 11 x64.
+database snapshots, and official TV Time exports. It also contains a private x64 Windows app
+candidate for Android and export recovery on Windows 10 1809 or later, plus encrypted iOS backup
+recovery on Windows 11 x64.
+
+The public alpha artifact set is deliberately narrower: signed and notarized Apple silicon and
+Intel DMGs plus verified Python wheel and source packages. It does not include an MSIX or another
+public Windows binary. Advanced Windows testers may use the Python CLI or the private source-build
+instructions in `docs/windows.md`.
 
 The application code adds no network client, telemetry, WebView, or AI feature. Final Windows MSIX
-membership and third-party notice verification remain required before making the same claim about
-the packaged Windows artifact.
+membership and third-party notice verification remain required before any Windows binary can be
+published.
+
+Android recovery is experimental and limited to compatible legacy backups, already-preserved
+snapshots, or official exports. Device backup policy and recovered schemas vary; modern devices
+commonly fail closed. A successful synthetic fixture does not claim that a particular physical
+device or current TV Time app build is recoverable.
 
 ## Preparation evidence from 2026-08-01
 
-The merged source tree passed these preparation checks before this release-copy update:
+Merged commit `42f9aa5bdefe79c94e7e0913bf6ee9d96d103b5a` produced this exact-source
+preparation evidence:
 
 - 15 hosted CI jobs passed on macOS, Linux, and Windows for Python 3.10 through 3.13, including the
   native Windows compile and synthetic validator smoke;
-- 462 local Python tests passed with 13 expected platform-specific skips;
-- 119 Swift tests passed in debug and release, and the optimized Swift build passed;
-- Ruff, formatting, shell syntax, Python helper compilation, and Git diff checks passed;
 - source-bound Python wheel and source distributions passed exact membership, content, metadata,
   clean-install, dependency, command-help, and privacy checks;
 - the local arm64 app passed exact architecture, sandbox entitlement, deep signature, native
@@ -42,18 +51,33 @@ The merged source tree passed these preparation checks before this release-copy 
 - all eight public v0.2.0 assets were downloaded again and passed checksums, Developer ID signature,
   notarization ticket, Gatekeeper, architecture, version, and privacy checks.
 
+The diagnostics and release-documentation change set then passed 465 local Python tests
+with 13 expected platform-specific skips, 122 debug Swift tests, Ruff, formatting, shell syntax,
+Python helper compilation, and Git diff checks. These local results do not extend the earlier
+hosted or source-package evidence to the changed bytes.
+
 This is preparation evidence only. The final tagged commit must rerun every applicable gate after
 all release changes are merged.
 
-## Open release gates
+## Alpha confidence by route
 
-The prerelease must not be tagged or published until all of these are complete:
+- Existing macOS encrypted-iOS recovery: high. It retains the published v0.2.0 workflow and has
+  expanded Swift, helper, privacy, and packaging coverage.
+- macOS and Python official-export recovery: reasonable from synthetic end-to-end coverage.
+- Legacy Android backup or snapshot recovery: experimental and device/schema dependent.
+- Native Windows app: private and not included in this release. Compilation, validator smoke, and
+  hosted Windows lanes do not prove installation, UI behavior, NTFS behavior, or complete packaged
+  recovery.
+
+## Pre-tag alpha release gates
+
+The prerelease must not be tagged or uploaded until all of these are complete:
 
 1. Build the private MSIX from a source-bound immutable stage on supported native Windows 11 x64.
 2. Pass the real NTFS capability suite, install/package smoke, synthetic UI journey, and synthetic
    end-to-end recovery journey on that Windows build.
 3. Verify final MSIX membership, runtime-pack pins, binary-to-component notices, and the package
-   no-network/no-AI contract.
+   no-network/no-AI contract. The verified MSIX remains private and is not a public alpha asset.
 4. Validate a supported legacy Android capture where available and confirm documented fail-closed
    behavior on a modern device that does not expose compatible app data.
 5. Freeze one clean release commit and rerun the complete Python, Swift, formatting, privacy,
@@ -61,10 +85,17 @@ The prerelease must not be tagged or published until all of these are complete:
 6. Build fresh arm64 and x86_64 macOS DMGs from that commit with the official universal2 Python,
    Developer ID signing, hardened runtime, production entitlements, notarization, stapling,
    Gatekeeper assessment, native-license verification, manifests, and checksums.
-7. Test the final DMGs on supported clean Apple silicon and Intel systems, including synthetic
-   preflight, cancellation, retry, completion, report opening, and clean quit.
-8. Re-download every draft asset into a fresh directory and repeat checksum, signature,
-   notarization, stapling, Gatekeeper, architecture, version, provenance, and privacy verification.
+7. Exercise both architecture-specific packaged helpers and inspect the final DMGs. Confirm the
+   existing encrypted-iOS journey remains operational and the new export route completes with only
+   synthetic data. Keep any unavailable physical Intel-system validation explicit in the release
+   notes rather than treating Rosetta execution as identical hardware proof.
+
+## Draft verification gate
+
+After the tag is pushed and the complete asset set is uploaded to a draft prerelease, re-download
+every draft asset into a fresh directory and repeat checksum, signature, notarization, stapling,
+Gatekeeper, architecture, version, provenance, and privacy verification. The prerelease must remain
+draft until this passes.
 
 Native Windows and Android proof is tracked in
 [issue #13](https://github.com/amirbrooks/tvtime-backup-extractor/issues/13).
@@ -81,7 +112,7 @@ another repository.
 
 ## Publication sequence
 
-After every gate passes:
+After every pre-tag gate passes:
 
 1. Create an annotated `v0.3.0-alpha.1` tag locally from the exact reviewed commit and verify its
    peeled commit before any remote mutation.
@@ -90,6 +121,6 @@ After every gate passes:
 3. Create a draft GitHub prerelease with `--verify-tag`. Release tooling must not create or retarget
    the tag.
 4. Upload only the complete verified artifact set and its manifests/checksums.
-5. Download and reverify every draft asset.
+5. Complete the draft verification gate above.
 6. Publish as a prerelease while keeping v0.2.0 as latest stable.
 7. Update release-status copy only after GitHub confirms publication.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -51,6 +51,11 @@ The macOS app records only fixed operation, milestone, and allow-listed failure 
 local unified log. It does not log paths, backup identifiers, filenames, titles, recovered counts,
 passwords, or free-form error text, and it does not transmit telemetry.
 
+If the app reaches its failure screen, use **Copy Safe Diagnostics** under **Where recovery
+stopped**. The copied text shows the recent fixed operation, milestone, and failure codes for that
+attempt. Review it before sharing. Do not send a screenshot because the surrounding screen or other
+open apps can expose private information.
+
 For a contributor-built local app, run the repository's normal packaged build with its narrow
 telemetry filter:
 
@@ -64,8 +69,9 @@ failure contains an allow-listed `reason`; an unknown local error is only
 `unrecognized_failure`.
 
 Do not broaden the predicate, export a `.logarchive`, or attach terminal output to an issue. Other
-system logs can contain private data. Share only the app's displayed reference code and a manually
-paraphrased stage unless a maintainer provides a synthetic reproduction procedure.
+system logs can contain private data. Share only the copied Safe Diagnostics, the app's displayed
+reference code, and a manually paraphrased stage unless a maintainer provides a synthetic
+reproduction procedure.
 
 ## The backup is not marked finished
 

--- a/macos/Sources/TVTimeRecoveryApp/FolderPicker.swift
+++ b/macos/Sources/TVTimeRecoveryApp/FolderPicker.swift
@@ -59,18 +59,23 @@ final class FolderPicker {
       diagnostics.record(.milestone(.backupPicker, .pickerCancelled))
       return nil
     }
-    let keys: Set<URLResourceKey> =
-      kind == .androidPreservedSnapshot
-      ? [.isDirectoryKey, .isSymbolicLinkKey]
-      : [.isRegularFileKey, .isSymbolicLinkKey]
-    let values = try selected.resourceValues(forKeys: keys)
-    guard values.isSymbolicLink != true else { throw FolderPickerError.invalidDirectory }
-    if kind == .androidPreservedSnapshot {
-      guard values.isDirectory == true else { throw FolderPickerError.invalidDirectory }
-    } else {
-      guard values.isRegularFile == true else { throw FolderPickerError.invalidDirectory }
+    do {
+      let keys: Set<URLResourceKey> =
+        kind == .androidPreservedSnapshot
+        ? [.isDirectoryKey, .isSymbolicLinkKey]
+        : [.isRegularFileKey, .isSymbolicLinkKey]
+      let values = try selected.resourceValues(forKeys: keys)
+      guard values.isSymbolicLink != true else { throw FolderPickerError.invalidDirectory }
+      if kind == .androidPreservedSnapshot {
+        guard values.isDirectory == true else { throw FolderPickerError.invalidDirectory }
+      } else {
+        guard values.isRegularFile == true else { throw FolderPickerError.invalidDirectory }
+      }
+      return selected.standardizedFileURL
+    } catch {
+      diagnostics.record(.failure(.backupPicker, diagnosticFailure(for: error)))
+      throw error
     }
-    return selected.standardizedFileURL
   }
 
   private func chooseDirectory(

--- a/macos/Sources/TVTimeRecoveryApp/RecoveryRootView.swift
+++ b/macos/Sources/TVTimeRecoveryApp/RecoveryRootView.swift
@@ -7,7 +7,7 @@ struct RecoveryRootView: View {
   let folderPicker: FolderPicker
   let workspaceActions: WorkspaceActions
   let recoveryStore: AppManagedRecoveryStore
-  let diagnostics: any RecoveryDiagnosticsSink
+  let diagnostics: UnifiedRecoveryDiagnostics
   @State private var selectedSource = RecoverySourceChoice.iosBackup
 
   var body: some View {
@@ -74,10 +74,12 @@ struct RecoveryRootView: View {
       case .failed(let failure):
         RecoveryErrorView(
           failure: failure,
+          troubleshootingReport: diagnostics.troubleshootingReport,
           onPrimaryAction: session.recoverFromFailure,
           onStartOver: session.returnToBackupSelection,
           canRevealOutput: hasExistingOutput,
-          onRevealOutput: revealOutput
+          onRevealOutput: revealOutput,
+          onCopyTroubleshootingReport: workspaceActions.copyTroubleshootingReport
         )
       }
     }
@@ -114,8 +116,10 @@ struct RecoveryRootView: View {
 
       if selectedSource == .iosBackup {
         BackupStepView {
-          try await folderPicker.chooseBackup()
+          diagnostics.beginAttempt()
+          return try await folderPicker.chooseBackup()
         } onSelected: { url in
+          diagnostics.record(.milestone(.backupPicker, .backupAccepted))
           do {
             let destination = try recoveryStore.prepareDestination()
             diagnostics.record(.milestone(.preflight, .privateStoragePrepared))
@@ -125,6 +129,8 @@ struct RecoveryRootView: View {
             throw error
           }
         } onShowRecoveries: {
+          diagnostics.beginAttempt()
+          diagnostics.record(.milestone(.outputAccess, .requested))
           do {
             guard let destination = try recoveryStore.existingDestination() else {
               throw RootActionError.missingArtifact
@@ -134,19 +140,35 @@ struct RecoveryRootView: View {
             diagnostics.record(.failure(.outputAccess, .outputUnavailable))
             throw error
           }
+        } troubleshootingReport: {
+          diagnostics.troubleshootingReport
+        } onCopyTroubleshootingReport: {
+          try workspaceActions.copyTroubleshootingReport($0)
         }
       } else if let acquisitionKind = selectedSource.acquisitionKind {
         AcquisitionStepView(sourceKind: acquisitionKind) {
-          try await folderPicker.chooseAcquisitionSource(kind: acquisitionKind)
+          diagnostics.beginAttempt()
+          return try await folderPicker.chooseAcquisitionSource(kind: acquisitionKind)
         } onStart: { source, password, acknowledged in
-          let destination = try recoveryStore.prepareDestination()
-          session.startAcquisition(
-            sourceKind: acquisitionKind,
-            sourceURL: source,
-            appManagedDestinationParent: destination,
-            sourcePassword: password,
-            acknowledgeSensitiveOutput: acknowledged
-          )
+          diagnostics.beginSourceAttempt()
+          do {
+            let destination = try recoveryStore.prepareDestination()
+            diagnostics.record(.milestone(.recovery, .privateStoragePrepared))
+            session.startAcquisition(
+              sourceKind: acquisitionKind,
+              sourceURL: source,
+              appManagedDestinationParent: destination,
+              sourcePassword: password,
+              acknowledgeSensitiveOutput: acknowledged
+            )
+          } catch {
+            diagnostics.record(.failure(.recovery, .privateStorageUnavailable))
+            throw error
+          }
+        } troubleshootingReport: {
+          diagnostics.troubleshootingReport
+        } onCopyTroubleshootingReport: {
+          try workspaceActions.copyTroubleshootingReport($0)
         }
         .id(acquisitionKind.rawValue)
       }

--- a/macos/Sources/TVTimeRecoveryApp/RecoveryStepViews.swift
+++ b/macos/Sources/TVTimeRecoveryApp/RecoveryStepViews.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Charts
 import SwiftUI
 import TVTimeRecoveryCore
@@ -19,53 +20,69 @@ struct BackupStepView: View {
   let chooseBackup: () async throws -> URL?
   let onSelected: (URL) throws -> Void
   let onShowRecoveries: () throws -> Void
+  let troubleshootingReport: () -> RecoveryTroubleshootingReport
+  let onCopyTroubleshootingReport: (RecoveryTroubleshootingReport) throws -> Void
   @State private var presentedError: PresentedError?
+  @State private var showsTroubleshooting = false
 
   var body: some View {
-    VStack(spacing: 22) {
-      Image(systemName: "externaldrive")
-        .font(.system(size: 48))
-        .foregroundStyle(.tint)
-        .accessibilityHidden(true)
-      Text("Choose your encrypted local backup")
-        .font(.title2.weight(.semibold))
-        .phaseHeading()
-      Text(
-        "Select the completed Finder, Apple Devices, or iTunes backup. "
-          + "The app reads the backup without intentionally changing it."
-      )
-      .foregroundStyle(.secondary)
-      .multilineTextAlignment(.center)
-      .frame(maxWidth: 520)
-      Text(
-        "The picker normally opens at Apple’s Backup folder. If one backup is present, simply "
-          + "choose that folder. If several appear, open the backup you want first."
-      )
-      .font(.callout)
-      .foregroundStyle(.secondary)
-      .multilineTextAlignment(.center)
-      .frame(maxWidth: 520)
-      Button("Choose Backup…") {
-        Task {
-          do {
-            if let selected = try await chooseBackup() {
-              try onSelected(selected)
+    ScrollView {
+      VStack(spacing: 22) {
+        Image(systemName: "externaldrive")
+          .font(.system(size: 48))
+          .foregroundStyle(.tint)
+          .accessibilityHidden(true)
+        Text("Choose your encrypted local backup")
+          .font(.title2.weight(.semibold))
+          .phaseHeading()
+        Text(
+          "Select the completed Finder, Apple Devices, or iTunes backup. "
+            + "The app reads the backup without intentionally changing it."
+        )
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 520)
+        Text(
+          "The picker normally opens at Apple’s Backup folder. If one backup is present, simply "
+            + "choose that folder. If several appear, open the backup you want first."
+        )
+        .font(.callout)
+        .foregroundStyle(.secondary)
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: 520)
+        Button("Choose Backup…") {
+          showsTroubleshooting = false
+          Task {
+            do {
+              if let selected = try await chooseBackup() {
+                try onSelected(selected)
+              }
+            } catch {
+              presentedError = PresentedError(message: safeMessage(for: error))
+              showsTroubleshooting = true
             }
-          } catch {
-            presentedError = PresentedError(message: safeMessage(for: error))
           }
         }
-      }
-      .buttonStyle(.borderedProminent)
-      .controlSize(.large)
-      .keyboardShortcut(.defaultAction)
-      Button("Show Previous Recoveries") {
-        do {
-          try onShowRecoveries()
-        } catch {
-          presentedError = PresentedError(message: safeMessage(for: error))
+        .buttonStyle(.borderedProminent)
+        .controlSize(.large)
+        .keyboardShortcut(.defaultAction)
+        Button("Show Previous Recoveries") {
+          do {
+            try onShowRecoveries()
+          } catch {
+            presentedError = PresentedError(message: safeMessage(for: error))
+            showsTroubleshooting = true
+          }
+        }
+        if showsTroubleshooting, !troubleshootingReport().lines.isEmpty {
+          RecoveryTroubleshootingView(
+            report: troubleshootingReport(),
+            onCopy: onCopyTroubleshootingReport
+          )
         }
       }
+      .frame(maxWidth: .infinity)
+      .padding(.vertical, 1)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .alert(item: $presentedError) { error in
@@ -79,53 +96,69 @@ struct AcquisitionStepView: View {
   let sourceKind: AcquisitionSourceKind
   let chooseSource: () async throws -> URL?
   let onStart: (URL, String, Bool) throws -> Void
+  let troubleshootingReport: () -> RecoveryTroubleshootingReport
+  let onCopyTroubleshootingReport: (RecoveryTroubleshootingReport) throws -> Void
   @State private var selectedSource: URL?
   @State private var password = ""
   @State private var acknowledgesSensitiveOutput = false
   @State private var presentedError: PresentedError?
+  @State private var showsTroubleshooting = false
 
   var body: some View {
-    VStack(spacing: 20) {
-      Image(systemName: "lock.doc")
-        .font(.system(size: 48))
-        .foregroundStyle(.tint)
-      Text(title).font(.title2.weight(.semibold)).phaseHeading()
-      Text(guidance)
-        .foregroundStyle(.secondary)
-        .multilineTextAlignment(.center)
-        .frame(maxWidth: 560)
-      Button(selectedSource == nil ? "Choose Source…" : "Choose Different Source…") {
-        Task {
-          do { selectedSource = try await chooseSource() ?? selectedSource } catch {
-            presentedError = PresentedError(message: safeMessage(for: error))
+    ScrollView {
+      VStack(spacing: 20) {
+        Image(systemName: "lock.doc")
+          .font(.system(size: 48))
+          .foregroundStyle(.tint)
+        Text(title).font(.title2.weight(.semibold)).phaseHeading()
+        Text(guidance)
+          .foregroundStyle(.secondary)
+          .multilineTextAlignment(.center)
+          .frame(maxWidth: 560)
+        Button(selectedSource == nil ? "Choose Source…" : "Choose Different Source…") {
+          showsTroubleshooting = false
+          Task {
+            do { selectedSource = try await chooseSource() ?? selectedSource } catch {
+              presentedError = PresentedError(message: safeMessage(for: error))
+              showsTroubleshooting = true
+            }
           }
         }
-      }
-      .buttonStyle(.borderedProminent)
-      if selectedSource != nil {
-        Label("Private local source selected", systemImage: "checkmark.circle.fill")
-          .foregroundStyle(.secondary)
-      }
-      if sourceKind == .tvTimeOfficialExport {
-        SecureField("Export password (only if the ZIP is encrypted)", text: $password)
-          .textFieldStyle(.roundedBorder)
-          .frame(maxWidth: 480)
-      }
-      Toggle(isOn: $acknowledgesSensitiveOutput) {
-        Text("I understand the recovered reports contain readable private viewing history.")
-      }
-      .frame(maxWidth: 560)
-      Button("Recover Privately") {
-        guard let selectedSource else { return }
-        let suppliedPassword = password
-        password.removeAll(keepingCapacity: false)
-        do { try onStart(selectedSource, suppliedPassword, acknowledgesSensitiveOutput) } catch {
-          presentedError = PresentedError(message: safeMessage(for: error))
+        .buttonStyle(.borderedProminent)
+        if selectedSource != nil {
+          Label("Private local source selected", systemImage: "checkmark.circle.fill")
+            .foregroundStyle(.secondary)
+        }
+        if sourceKind == .tvTimeOfficialExport {
+          SecureField("Export password (only if the ZIP is encrypted)", text: $password)
+            .textFieldStyle(.roundedBorder)
+            .frame(maxWidth: 480)
+        }
+        Toggle(isOn: $acknowledgesSensitiveOutput) {
+          Text("I understand the recovered reports contain readable private viewing history.")
+        }
+        .frame(maxWidth: 560)
+        Button("Recover Privately") {
+          guard let selectedSource else { return }
+          let suppliedPassword = password
+          password.removeAll(keepingCapacity: false)
+          do { try onStart(selectedSource, suppliedPassword, acknowledgesSensitiveOutput) } catch {
+            presentedError = PresentedError(message: safeMessage(for: error))
+            showsTroubleshooting = true
+          }
+        }
+        .buttonStyle(.borderedProminent)
+        .keyboardShortcut(.defaultAction)
+        .disabled(selectedSource == nil || !acknowledgesSensitiveOutput)
+        if showsTroubleshooting, !troubleshootingReport().lines.isEmpty {
+          RecoveryTroubleshootingView(
+            report: troubleshootingReport(),
+            onCopy: onCopyTroubleshootingReport
+          )
         }
       }
-      .buttonStyle(.borderedProminent)
-      .keyboardShortcut(.defaultAction)
-      .disabled(selectedSource == nil || !acknowledgesSensitiveOutput)
+      .frame(maxWidth: .infinity)
+      .padding(.vertical, 1)
     }
     .frame(maxWidth: .infinity, maxHeight: .infinity)
     .alert(item: $presentedError) { error in
@@ -716,10 +749,12 @@ struct RecoveryResultView: View {
 @MainActor
 struct RecoveryErrorView: View {
   let failure: RecoveryFailure
+  let troubleshootingReport: RecoveryTroubleshootingReport
   let onPrimaryAction: () -> Void
   let onStartOver: () -> Void
   let canRevealOutput: Bool
   let onRevealOutput: () throws -> Void
+  let onCopyTroubleshootingReport: (RecoveryTroubleshootingReport) throws -> Void
   @State private var presentedError: PresentedError?
 
   private var recoveryPlan: RecoveryFailureRecoveryPlan {
@@ -760,6 +795,12 @@ struct RecoveryErrorView: View {
           .textSelection(.enabled)
           .accessibilityLabel("Error reference")
           .accessibilityValue(failure.userVisibleReferenceCode)
+        if !troubleshootingReport.lines.isEmpty {
+          RecoveryTroubleshootingView(
+            report: troubleshootingReport,
+            onCopy: onCopyTroubleshootingReport
+          )
+        }
         if canRevealOutput {
           Text(
             "Incomplete output is preserved. Reveal it before starting over if you need to "
@@ -806,6 +847,59 @@ struct RecoveryErrorView: View {
         .keyboardShortcut(.defaultAction)
     }
     Button("Start Over", action: onStartOver)
+  }
+}
+
+@MainActor
+private struct RecoveryTroubleshootingView: View {
+  let report: RecoveryTroubleshootingReport
+  let onCopy: (RecoveryTroubleshootingReport) throws -> Void
+  @State private var copiedReportText: String?
+  @State private var presentedError: PresentedError?
+
+  var body: some View {
+    GroupBox {
+      VStack(alignment: .leading, spacing: 10) {
+        ScrollView {
+          Text(report.lines.joined(separator: "\n"))
+            .font(.caption.monospaced())
+            .foregroundStyle(.secondary)
+            .textSelection(.enabled)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .frame(maxHeight: 140)
+        HStack(spacing: 10) {
+          Button("Copy Safe Diagnostics") {
+            do {
+              try onCopy(report)
+              copiedReportText = report.text
+              NSAccessibility.post(
+                element: NSApp as Any,
+                notification: .announcementRequested,
+                userInfo: [
+                  .announcement: "Safe diagnostics copied",
+                  .priority: NSAccessibilityPriorityLevel.high.rawValue,
+                ]
+              )
+            } catch {
+              copiedReportText = nil
+              presentedError = PresentedError(message: safeMessage(for: error))
+            }
+          }
+          if copiedReportText == report.text {
+            Label("Copied", systemImage: "checkmark")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+    } label: {
+      Label("Where recovery stopped", systemImage: "stethoscope")
+    }
+    .frame(maxWidth: 540)
+    .alert(item: $presentedError) { error in
+      Alert(title: Text("Copy unavailable"), message: Text(error.message))
+    }
   }
 }
 

--- a/macos/Sources/TVTimeRecoveryApp/WorkspaceActions.swift
+++ b/macos/Sources/TVTimeRecoveryApp/WorkspaceActions.swift
@@ -4,6 +4,13 @@ import TVTimeRecoveryCore
 
 @MainActor
 final class WorkspaceActions {
+  func copyTroubleshootingReport(_ report: RecoveryTroubleshootingReport) throws {
+    NSPasteboard.general.clearContents()
+    guard NSPasteboard.general.setString(report.text, forType: .string) else {
+      throw WorkspaceActionError.copyFailed
+    }
+  }
+
   func openReport(_ report: URL, within output: URL) throws {
     try validate(report, within: output, expectedDirectory: false)
     guard NSWorkspace.shared.open(report) else {
@@ -98,12 +105,15 @@ final class WorkspaceActions {
 }
 
 private enum WorkspaceActionError: LocalizedError {
+  case copyFailed
   case unsafeArtifact
   case missingArtifact
   case openFailed
 
   var errorDescription: String? {
     switch self {
+    case .copyFailed:
+      "macOS could not copy the safe diagnostics. Select the text and copy it manually."
     case .unsafeArtifact:
       "The recovered artifact did not pass the local path safety check."
     case .missingArtifact:

--- a/macos/Sources/TVTimeRecoveryCore/RecoveryDiagnostics.swift
+++ b/macos/Sources/TVTimeRecoveryCore/RecoveryDiagnostics.swift
@@ -175,16 +175,40 @@ extension RecoveryAction {
 public enum RecoveryDiagnosticEvent: Equatable, Sendable {
   case milestone(RecoveryDiagnosticOperation, RecoveryDiagnosticMilestone)
   case failure(RecoveryDiagnosticOperation, RecoveryDiagnosticFailure)
+
+  fileprivate var safeLine: String {
+    switch self {
+    case .milestone(let operation, let milestone):
+      "operation=\(operation.rawValue) event=\(milestone.rawValue)"
+    case .failure(let operation, let failure):
+      "operation=\(operation.rawValue) event=failed reason=\(failure.rawValue)"
+    }
+  }
+}
+
+public struct RecoveryTroubleshootingReport: Equatable, Sendable {
+  public let lines: [String]
+
+  public var text: String {
+    (["TV Time Backup Extractor safe diagnostics"] + lines).joined(separator: "\n")
+  }
 }
 
 @MainActor
 public protocol RecoveryDiagnosticsSink: AnyObject {
+  func beginAttempt()
   func record(_ event: RecoveryDiagnosticEvent)
 }
 
 @MainActor
 public final class UnifiedRecoveryDiagnostics: RecoveryDiagnosticsSink {
+  private static let trailLimit = 16
   private let logger: Logger
+  private var recentEvents: [RecoveryDiagnosticEvent] = []
+
+  public var troubleshootingReport: RecoveryTroubleshootingReport {
+    RecoveryTroubleshootingReport(lines: recentEvents.map(\.safeLine))
+  }
 
   public init(
     subsystem: String = "com.amirbrooks.tvtime-backup-extractor",
@@ -193,7 +217,20 @@ public final class UnifiedRecoveryDiagnostics: RecoveryDiagnosticsSink {
     logger = Logger(subsystem: subsystem, category: category)
   }
 
+  public func beginAttempt() {
+    recentEvents.removeAll(keepingCapacity: true)
+  }
+
+  public func beginSourceAttempt() {
+    beginAttempt()
+    record(.milestone(.backupPicker, .backupAccepted))
+  }
+
   public func record(_ event: RecoveryDiagnosticEvent) {
+    recentEvents.append(event)
+    if recentEvents.count > Self.trailLimit {
+      recentEvents.removeFirst(recentEvents.count - Self.trailLimit)
+    }
     switch event {
     case .milestone(let operation, let milestone):
       logger.info(

--- a/macos/Sources/TVTimeRecoveryCore/RecoverySession.swift
+++ b/macos/Sources/TVTimeRecoveryCore/RecoverySession.swift
@@ -350,8 +350,6 @@ public final class RecoverySession {
     outputDirectory = freshOutputDirectory(in: appManagedDestinationParent)
     preflightSummary = nil
     backupReceipt = nil
-    diagnostics.record(.milestone(.backupPicker, .backupAccepted))
-    diagnostics.record(.milestone(.preflight, .requested))
     startPreflight()
   }
 
@@ -426,8 +424,7 @@ public final class RecoverySession {
       activeAction = nil
       sourceLease.stop()
       destinationLease.stop()
-      diagnostics.record(.failure(.recovery, RecoveryDiagnosticFailure(error: error)))
-      failSafely(error)
+      failSafely(error, operation: .recovery)
     }
   }
 
@@ -449,6 +446,7 @@ public final class RecoverySession {
       if let count = secret?.count, count > 0 { secret?.resetBytes(in: 0..<count) }
     }
     do {
+      diagnostics.record(.milestone(.recovery, .requested))
       let identity = try destinationEncryptionValidator(destination)
       backupDirectory = source
       destinationParent = destination
@@ -483,7 +481,7 @@ public final class RecoverySession {
     } catch {
       sourceLease.stop()
       destinationLease.stop()
-      failSafely(error)
+      failSafely(error, operation: .recovery)
     }
   }
 
@@ -667,6 +665,7 @@ public final class RecoverySession {
     }
     preflightSummary = nil
     backupReceipt = nil
+    diagnostics.record(.milestone(.preflight, .requested))
     let sourceLease = SecurityScopedResourceLease(url: backupDirectory)
     let destinationLease = SecurityScopedResourceLease(url: destinationParent)
     do {
@@ -698,11 +697,10 @@ public final class RecoverySession {
         retainDestinationOnSuccess: false
       )
     } catch {
-      diagnostics.record(.failure(.preflight, RecoveryDiagnosticFailure(error: error)))
       activeAction = nil
       sourceLease.stop()
       destinationLease.stop()
-      failSafely(error)
+      failSafely(error, operation: .preflight)
     }
   }
 
@@ -738,10 +736,6 @@ public final class RecoverySession {
       } catch {
         sourceLease.stop()
         destinationLease.stop()
-        diagnostics.record(
-          .failure(
-            activeAction?.diagnosticOperation ?? .recovery, RecoveryDiagnosticFailure(error: error))
-        )
         failSafely(error)
       }
       operationTask = nil
@@ -827,6 +821,8 @@ public final class RecoverySession {
             message: "Validating recovered output…"
           )
         )
+        diagnostics.record(.milestone(.recovery, .completed))
+        diagnostics.record(.milestone(.validation, .started))
         let validator = acquisitionOutputValidator
         let task = Task.detached(priority: .userInitiated) {
           try validator(summary, outputDirectory)
@@ -838,6 +834,7 @@ public final class RecoverySession {
           throw CancellationError()
         }
         phase = .acquisitionCompleted(summary)
+        diagnostics.record(.milestone(.validation, .completed))
       } catch is CancellationError {
         failValidationCancellation()
       } catch {
@@ -874,7 +871,12 @@ public final class RecoverySession {
     }
   }
 
-  private func failSafely(_ error: Error) {
+  private func failSafely(
+    _ error: Error,
+    operation explicitOperation: RecoveryDiagnosticOperation? = nil
+  ) {
+    let operation = explicitOperation ?? activeAction?.diagnosticOperation ?? .recovery
+    diagnostics.record(.failure(operation, RecoveryDiagnosticFailure(error: error)))
     cancelPendingInterruptionRequests()
     activeAction = nil
     backupReceipt = nil
@@ -1033,6 +1035,7 @@ public final class RecoverySession {
     cancellationSignalSent = false
     preflightSummary = nil
     backupReceipt = nil
+    diagnostics.beginAttempt()
     if useFreshOutput {
       outputDirectory = freshOutputDirectory(
         in: destinationParent,

--- a/macos/Tests/TVTimeRecoveryCoreTests/RecoveryDiagnosticsTests.swift
+++ b/macos/Tests/TVTimeRecoveryCoreTests/RecoveryDiagnosticsTests.swift
@@ -96,6 +96,68 @@ struct RecoveryDiagnosticsTests {
       )
     }
   }
+
+  @Test @MainActor
+  func testTroubleshootingReportContainsOnlyBoundedFixedVocabulary() {
+    let diagnostics = UnifiedRecoveryDiagnostics(
+      subsystem: "com.example.synthetic",
+      category: "SyntheticDiagnostics"
+    )
+    diagnostics.record(.milestone(.recovery, .requested))
+    diagnostics.record(.failure(.recovery, .helperCommunicationFailed))
+
+    let report = diagnostics.troubleshootingReport
+    expectEqual(
+      report.lines,
+      [
+        "operation=recovery event=requested",
+        "operation=recovery event=failed reason=helper_communication_failed",
+      ]
+    )
+    expectEqual(
+      report.text,
+      "TV Time Backup Extractor safe diagnostics\n"
+        + "operation=recovery event=requested\n"
+        + "operation=recovery event=failed reason=helper_communication_failed"
+    )
+  }
+
+  @Test @MainActor
+  func testTroubleshootingTrailIsBoundedAndResetForANewAttempt() {
+    let diagnostics = UnifiedRecoveryDiagnostics(
+      subsystem: "com.example.synthetic",
+      category: "SyntheticDiagnostics"
+    )
+    for _ in 0..<20 {
+      diagnostics.record(.milestone(.validation, .started))
+    }
+    expectEqual(diagnostics.troubleshootingReport.lines.count, 16)
+
+    diagnostics.beginAttempt()
+    expectTrue(diagnostics.troubleshootingReport.lines.isEmpty)
+    diagnostics.record(.failure(.backupPicker, .pickerInvalidDirectory))
+    expectEqual(
+      diagnostics.troubleshootingReport.lines,
+      ["operation=backup_picker event=failed reason=picker_invalid_directory"]
+    )
+  }
+
+  @Test @MainActor
+  func testCommittedSourceReplacesCancelledPickerTrail() {
+    let diagnostics = UnifiedRecoveryDiagnostics(
+      subsystem: "com.example.synthetic",
+      category: "SyntheticDiagnostics"
+    )
+    diagnostics.record(.milestone(.backupPicker, .pickerPresented))
+    diagnostics.record(.milestone(.backupPicker, .pickerCancelled))
+
+    diagnostics.beginSourceAttempt()
+
+    expectEqual(
+      diagnostics.troubleshootingReport.lines,
+      ["operation=backup_picker event=backup_accepted"]
+    )
+  }
 }
 
 private struct SensitiveSyntheticError: LocalizedError {

--- a/macos/Tests/TVTimeRecoveryCoreTests/RecoverySessionTests.swift
+++ b/macos/Tests/TVTimeRecoveryCoreTests/RecoverySessionTests.swift
@@ -67,8 +67,10 @@ final class RecoverySessionTests {
   @Test
   func testAcquisitionFailureReturnsToSourceSelectionInsteadOfIOSPreflight() throws {
     let helper = FakeRecoveryHelperClient()
+    let diagnostics = RecordingRecoveryDiagnostics()
     let session = RecoverySession(
       helperClient: helper,
+      diagnostics: diagnostics,
       destinationEncryptionValidator: { _ in syntheticDestinationIdentity }
     )
     let root = try trackedDirectory()
@@ -92,6 +94,13 @@ final class RecoverySessionTests {
 
     expectEqual(session.phase, .chooseBackup)
     expectEqual(helper.invocations.count, 0)
+    expectEqual(
+      diagnostics.events,
+      [
+        .milestone(.recovery, .requested),
+        .failure(.recovery, .invalidFrame),
+      ]
+    )
   }
 
   @Test
@@ -651,7 +660,8 @@ final class RecoverySessionTests {
   func testPasswordFailureCreatesFreshOutputAndRequiresNewPreflightBeforeConfirmation()
     async throws
   {
-    let context = try await makeRunningSession()
+    let diagnostics = RecordingRecoveryDiagnostics()
+    let context = try await makeRunningSession(diagnostics: diagnostics)
     let originalOutput = try requireValue(context.session.outputDirectory)
     try await deliverFailure(code: "backup_password_rejected", to: context)
     expectEqual(context.session.preflightSummary, TestFixtures.preflight())
@@ -670,6 +680,14 @@ final class RecoverySessionTests {
     guard case .preflighting = context.session.phase else {
       return failTest("Expected password recovery to rerun preflight")
     }
+    expectEqual(diagnostics.beginAttemptCalls, 1)
+    expectEqual(
+      diagnostics.events,
+      [
+        .milestone(.preflight, .requested),
+        .milestone(.preflight, .started),
+      ]
+    )
 
     let refreshedSummary = TestFixtures.preflight(backupRegularFiles: 102)
     context.helper.send(
@@ -791,7 +809,6 @@ final class RecoverySessionTests {
     expectEqual(
       diagnostics.events,
       [
-        .milestone(.backupPicker, .backupAccepted),
         .milestone(.preflight, .requested),
         .milestone(.preflight, .started),
         .milestone(.preflight, .completed),
@@ -804,10 +821,13 @@ final class RecoverySessionTests {
     )
   }
 
-  private func makePreflightingSession() throws -> SessionContext {
+  private func makePreflightingSession(
+    diagnostics: any RecoveryDiagnosticsSink = UnifiedRecoveryDiagnostics()
+  ) throws -> SessionContext {
     let helper = FakeRecoveryHelperClient()
     let session = RecoverySession(
       helperClient: helper,
+      diagnostics: diagnostics,
       destinationEncryptionValidator: { _ in syntheticDestinationIdentity }
     )
     let root = try trackedDirectory()
@@ -826,8 +846,10 @@ final class RecoverySessionTests {
     return SessionContext(session: session, helper: helper)
   }
 
-  private func makeRunningSession() async throws -> SessionContext {
-    let context = try makePreflightingSession()
+  private func makeRunningSession(
+    diagnostics: any RecoveryDiagnosticsSink = UnifiedRecoveryDiagnostics()
+  ) async throws -> SessionContext {
+    let context = try makePreflightingSession(diagnostics: diagnostics)
     context.helper.send(try TestFixtures.preflightCompletionEvent(), finish: true)
     try await waitUntil { context.session.phase == .confirm(TestFixtures.preflight()) }
     context.session.startRecovery(password: "password", acknowledgeSensitiveOutput: true)
@@ -1002,6 +1024,12 @@ private enum FakeError: Error {
 @MainActor
 private final class RecordingRecoveryDiagnostics: RecoveryDiagnosticsSink {
   private(set) var events: [RecoveryDiagnosticEvent] = []
+  private(set) var beginAttemptCalls = 0
+
+  func beginAttempt() {
+    beginAttemptCalls += 1
+    events.removeAll(keepingCapacity: true)
+  }
 
   func record(_ event: RecoveryDiagnosticEvent) {
     events.append(event)


### PR DESCRIPTION
## Summary

- adds a bounded, copyable Safe Diagnostics trail using only fixed operation, milestone, and failure codes
- covers picker, storage, preflight, recovery, validation, retry, cancellation, and previous-recovery access without paths, identifiers, content, counts, passwords, or raw errors
- keeps startup troubleshooting usable in the minimum window and with accessibility text sizes
- defines the scoped v0.3.0-alpha.1 public artifact set and preserves the remaining native/signing gates

## Validation

- 465 Python tests passed with 13 expected platform-specific skips
- 122 Swift tests passed in debug and release; optimized build passed
- Ruff, Swift formatting, shell/Python syntax, and diff checks passed
- source-bound wheel/sdist privacy, membership, metadata, and clean-install help smoke passed
- local arm64 sandboxed app passed architecture, signature, entitlements, privacy, packaged-helper synthetic preflight, launch, and clean quit
- final Codex review: no accepted/actionable findings

## Release boundary

This PR does not create or publish a release. Native Windows/Android proof and fresh signed, notarized, stapled dual-architecture DMGs remain pre-tag gates in the release record.