### PR TITLE
Bound recovery error references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ evidence, release gates, and remaining native proof.
   published v0.2.0 encrypted-iOS-backup workflow.
 - Added a copyable, bounded Safe Diagnostics trail to the macOS failure screen. It reports only
   fixed operation, milestone, and failure codes and does not include raw errors or private values.
+  Displayed error references use the same exact allowlist; unknown helper values fail closed as
+  `unrecognized_failure`.
 - Added privacy-safe Android capability probing and explicitly acknowledged legacy-device capture.
   Modern release apps, disabled backup policy, multiple devices, and unauthorized devices fail
   closed.

--- a/docs/release-notes-v0.3.0-alpha.1.md
+++ b/docs/release-notes-v0.3.0-alpha.1.md
@@ -39,5 +39,10 @@ private owner-controlled local storage. For encrypted-iOS recovery, use a comple
 backup and disconnect the phone after confirming that backup has finished. Opening a report can add
 its private filename to browser or viewer history and Recent Items.
 
+If recovery stops in the macOS app, use **Copy Safe Diagnostics** and share only that bounded text
+plus a manual description of the stage. Unknown failures are reported as `unrecognized_failure`.
+Do not send a screenshot, complete log archive, backup, database, export, report, or recovered
+output.
+
 This project is independent and is not affiliated with or endorsed by TV Time, Apple, Google, or
 Microsoft.

--- a/macos/Sources/TVTimeRecoveryCore/RecoverySession.swift
+++ b/macos/Sources/TVTimeRecoveryCore/RecoverySession.swift
@@ -49,19 +49,7 @@ extension RecoveryFailure {
   }
 
   public var userVisibleReferenceCode: String {
-    guard
-      !code.isEmpty,
-      code.count <= 64,
-      code.unicodeScalars.allSatisfy({ scalar in
-        scalar.isASCII
-          && ((scalar.value >= 97 && scalar.value <= 122)
-            || (scalar.value >= 48 && scalar.value <= 57)
-            || scalar.value == 95)
-      })
-    else {
-      return "unrecognized_failure"
-    }
-    return code
+    RecoveryDiagnosticFailure(recoveryFailureCode: code).rawValue
   }
 
   public var recoveryPlan: RecoveryFailureRecoveryPlan {

--- a/macos/Tests/TVTimeRecoveryCoreTests/RecoveryDiagnosticsTests.swift
+++ b/macos/Tests/TVTimeRecoveryCoreTests/RecoveryDiagnosticsTests.swift
@@ -6,16 +6,36 @@ import Testing
 @Suite("Privacy-safe recovery diagnostics")
 struct RecoveryDiagnosticsTests {
   @Test
-  func testFailureCodesAreAnExactAllowList() {
-    expectEqual(
-      RecoveryDiagnosticFailure(recoveryFailureCode: "backup_unencrypted"),
-      .backupUnencrypted
-    )
-    expectEqual(
-      RecoveryDiagnosticFailure(recoveryFailureCode: "local_helper_error"),
-      .localHelperError
-    )
+  func testEveryRecoveryFailureCodeHasAnExplicitDiagnosticTag() {
+    let expected: [(String, RecoveryDiagnosticFailure)] = [
+      ("invalid_input", .invalidInput),
+      ("backup_unencrypted", .backupUnencrypted),
+      ("backup_unfinished", .backupUnfinished),
+      ("app_data_missing", .appDataMissing),
+      ("source_changed", .sourceChanged),
+      ("unsupported_schema", .unsupportedSchema),
+      ("insufficient_space", .insufficientSpace),
+      ("output_exists", .outputExists),
+      ("unsafe_path", .unsafePath),
+      ("destination_unencrypted", .destinationUnencrypted),
+      ("backup_password_rejected", .backupPasswordRejected),
+      ("preflight_cancelled", .preflightCancelled),
+      ("cancelled", .cancelled),
+      ("partial_extraction", .partialExtraction),
+      ("recovery_failed", .recoveryFailed),
+      ("local_helper_error", .localHelperError),
+      ("output_validation_failed", .outputValidationFailed),
+    ]
+
+    for (code, diagnostic) in expected {
+      expectEqual(RecoveryDiagnosticFailure(recoveryFailureCode: code), diagnostic, code)
+    }
+  }
+
+  @Test
+  func testUnknownFailureCodesFailClosed() {
     for unsafe in [
+      "future_failure_2",
       "/Users/example/Library/Application Support/MobileSync/Backup/private",
       "password=do-not-log",
       "A Show Title",

--- a/macos/Tests/TVTimeRecoveryCoreTests/RecoveryFailureRecoveryPlanTests.swift
+++ b/macos/Tests/TVTimeRecoveryCoreTests/RecoveryFailureRecoveryPlanTests.swift
@@ -226,13 +226,13 @@ struct RecoveryFailureRecoveryPlanTests {
   }
 
   @Test
-  func testReferenceCodeAllowsOnlyBoundedLowercaseProtocolIdentifiers() {
+  func testReferenceCodeUsesOnlyTheFixedDiagnosticAllowList() {
     let safeUnknownFailure = RecoveryFailure(
       code: "future_failure_2",
       message: "Hidden for unknown failures.",
       retryable: true
     )
-    expectEqual(safeUnknownFailure.userVisibleReferenceCode, "future_failure_2")
+    expectEqual(safeUnknownFailure.userVisibleReferenceCode, "unrecognized_failure")
 
     let rejectedCodes = [
       "", "UPPERCASE", "path/failure", "failure-name", String(repeating: "a", count: 65),


### PR DESCRIPTION
## Summary
- keep displayed recovery references on the same fixed diagnostic allowlist
- map unknown helper values to `unrecognized_failure`
- tell alpha testers how to share bounded diagnostics safely

## Validation
- Python: Ruff + 465 tests (13 expected platform skips)
- Swift: 123 debug + 123 release tests; release build
- source-bound wheel/sdist verification and privacy scan
- two Terra-max review lanes: no actionable findings
- content-copy lint and `git diff --check`