### PR TITLE
docs: record v0.3.0 alpha release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes are documented here. The project follows semantic versioning.
 
-## Unreleased prerelease candidate: v0.3.0-alpha.1
+## 0.3.0-alpha.1 - 2026-08-01
 
-This is the planned first alpha for the 0.3.0 cross-platform work. It remains unpublished.
-Successful synthetic checks do not make every device route verified, and the public alpha artifact
-set deliberately excludes a Windows binary.
+This experimental GitHub prerelease is the first alpha for the 0.3.0 cross-platform work.
+Successful synthetic checks do not make every device route verified. Its public artifact set
+deliberately excludes a Windows binary.
 
 See the [v0.3.0-alpha.1 release preparation record](docs/release-v0.3.0-alpha.1.md) for completed
 evidence, release gates, and remaining native proof.
@@ -57,9 +57,9 @@ evidence, release gates, and remaining native proof.
   still requires a synthetic Windows UI smoke test before it is considered release-ready.
 - Preserved recovered TVDB IDs, rewatch counts, aggregate series progress, and episode-special flags
   in normalized tables.
-- This prerelease candidate has not been tagged, uploaded, or published. Its intended public assets
-  are signed/notarized Apple silicon and Intel DMGs plus verified Python wheel/source packages; no
-  MSIX is included. v0.2.0 remains the current stable release.
+- Published signed, notarized, stapled, and Gatekeeper-accepted Apple silicon and Intel DMGs plus
+  verified Python wheel and source packages. No MSIX is included. v0.2.0 remains the latest stable
+  release.
 
 ## 0.2.0 - 2026-07-20
 

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ human-readable reports plus detailed CSV tables.
 The project is free and open source. iMazing is not required. It does not modify the phone or source
 backup, contact TV Time, restore data to the app, or provide an official cloud-account export.
 
-> **Release status:** [v0.2.0 is published](https://github.com/amirbrooks/tvtime-backup-extractor/releases/tag/v0.2.0)
-> with separate Developer ID-signed, notarized, and stapled DMGs for Apple silicon and Intel, plus
-> verified Python wheel and source packages. Download only from the official release and verify the
-> DMG against `SHA256SUMS`. Version 0.2.0 includes the complete Markdown catalogue, shared offline
-> HTML/PDF views, and native macOS recovery experience. This checkout also contains the unpublished
-> v0.3.0-alpha.1 prerelease candidate. Its Windows and Android changes are not part of public
-> v0.2.0.
+> **Release status:** [v0.2.0](https://github.com/amirbrooks/tvtime-backup-extractor/releases/tag/v0.2.0)
+> remains the latest stable release. Technical testers can also try the
+> [v0.3.0-alpha.1 prerelease](https://github.com/amirbrooks/tvtime-backup-extractor/releases/tag/v0.3.0-alpha.1),
+> which provides separate Developer ID-signed, notarized, and stapled DMGs for Apple silicon and
+> Intel, plus verified Python wheel and source packages. The alpha adds experimental Android and
+> official-export recovery. It includes no Windows binary. Download only from the official release
+> and verify the selected DMG against `SHA256SUMS`.
 
-The [v0.3.0-alpha.1 release preparation record](docs/release-v0.3.0-alpha.1.md) tracks completed
-evidence, the intentionally limited public artifact set, and the remaining alpha release gates.
+The [v0.3.0-alpha.1 release record](docs/release-v0.3.0-alpha.1.md) documents its evidence,
+intentionally limited public artifact set, and deferred device validation.
 
 This project is independent and is not affiliated with or endorsed by TV Time or Apple. TV Time and
 related marks belong to their respective owners. Use it only with data you own or are authorized to

--- a/docs/release-v0.3.0-alpha.1.md
+++ b/docs/release-v0.3.0-alpha.1.md
@@ -2,19 +2,21 @@
 
 ## Current status
 
-This prerelease is not published. No `v0.3.0-alpha.1` tag, GitHub release, or public alpha artifact
-exists yet.
+This prerelease was published on 2026-08-01 from tagged commit
+`9b61b27e670b12bd16a072e0e8c61121dc89c13f`:
 
-- `v0.2.0` remains the current stable release.
-- The intended GitHub tag is `v0.3.0-alpha.1` and must be marked as a prerelease, not latest.
+- [GitHub release](https://github.com/amirbrooks/tvtime-backup-extractor/releases/tag/v0.3.0-alpha.1)
+- eight public assets: two architecture-specific Mac DMGs, two Mac manifests, Mac checksums, a
+  Python wheel, a Python source archive, and a Python release manifest
+
+- `v0.2.0` remains the latest stable release. GitHub marks `v0.3.0-alpha.1` as a prerelease, not
+  latest.
 - Release metadata identifies the same alpha without violating platform version formats:
   `0.3.0a1` for Python, `0.3.0` plus bundle build `1` and the explicit
   `TVTimeReleaseVersion=0.3.0-alpha.1` for macOS, and private MSIX identity `0.3.0.1` with an Alpha
   display name for Windows. Artifact filenames use `0.3.0-alpha.1`. A later stable build must use
   new filenames and increment the native build and package version numbers without changing stable
   application identifiers.
-- Tagging and uploading remain blocked until every pre-tag gate in this record passes on one frozen
-  source commit. Publication remains blocked until the uploaded draft assets pass revalidation.
 
 ## Alpha scope
 
@@ -37,27 +39,22 @@ snapshots, or official exports. Device backup policy and recovered schemas vary;
 commonly fail closed. A successful synthetic fixture does not claim that a particular physical
 device or current TV Time app build is recoverable.
 
-## Preparation evidence from 2026-08-01
+## Final release evidence from 2026-08-01
 
-Merged commit `42f9aa5bdefe79c94e7e0913bf6ee9d96d103b5a` produced this exact-source
-preparation evidence:
+Tagged commit `9b61b27e670b12bd16a072e0e8c61121dc89c13f` produced the published assets:
 
 - 15 hosted CI jobs passed on macOS, Linux, and Windows for Python 3.10 through 3.13, including the
   native Windows compile and synthetic validator smoke;
 - source-bound Python wheel and source distributions passed exact membership, content, metadata,
   clean-install, dependency, command-help, and privacy checks;
-- the local arm64 app passed exact architecture, sandbox entitlement, deep signature, native
-  license, packaged-helper synthetic preflight, privacy, launch, and clean-quit checks; and
-- all eight public v0.2.0 assets were downloaded again and passed checksums, Developer ID signature,
-  notarization ticket, Gatekeeper, architecture, version, and privacy checks.
-
-The diagnostics and release-documentation change set then passed 465 local Python tests
-with 13 expected platform-specific skips, 122 debug Swift tests, Ruff, formatting, shell syntax,
-Python helper compilation, and Git diff checks. These local results do not extend the earlier
-hosted or source-package evidence to the changed bytes.
-
-This is preparation evidence only. The final tagged commit must rerun every applicable gate after
-all release changes are merged.
+- the arm64 and x86_64 apps and packaged helpers passed exact architecture, sandbox entitlement,
+  deep signature, native-license, synthetic protocol, privacy, notarization, stapling, and
+  Gatekeeper checks;
+- both DMGs passed their own Developer ID signing, notarization, stapling, Gatekeeper, mounted-image,
+  link-containment, manifest, and checksum checks; and
+- all eight draft assets were downloaded into a fresh directory and matched the verified originals
+  byte for byte before publication. The downloaded Mac and Python artifacts then repeated their
+  source, privacy, checksum, signature, ticket, Gatekeeper, manifest, and link-containment checks.
 
 ## Alpha confidence by route
 

--- a/tests/test_windows_private_packaging.py
+++ b/tests/test_windows_private_packaging.py
@@ -785,7 +785,7 @@ class WindowsPrivatePackagingContractTests(unittest.TestCase):
         ):
             self.assertTrue((ROOT / required).is_file())
 
-    def test_alpha_candidate_version_cannot_masquerade_as_published_v020(self) -> None:
+    def test_published_alpha_cannot_masquerade_as_stable_or_public_windows(self) -> None:
         self.assertIn('version = "0.3.0a1"', self.read("pyproject.toml"))
         self.assertIn('__version__ = "0.3.0a1"', self.read("tvtime_extractor/__init__.py"))
         self.assertIn(
@@ -820,12 +820,19 @@ class WindowsPrivatePackagingContractTests(unittest.TestCase):
         self.assertIn("release-$RELEASE_VERSION-macos", release_builder)
         self.assertIn("$RELEASE_VERSION-macOS-$package_label.dmg", release_builder)
         changelog = self.read("CHANGELOG.md")
-        self.assertIn("Unreleased prerelease candidate: v0.3.0-alpha.1", changelog)
-        self.assertIn("has not been tagged, uploaded, or published", changelog)
-        self.assertRegex(changelog, r"v0\.2\.0 remains the current\s+stable release")
+        self.assertIn("## 0.3.0-alpha.1 - 2026-08-01", changelog)
+        self.assertIn("No MSIX is included", changelog)
+        self.assertRegex(changelog, r"v0\.2\.0 remains the latest stable\s+release")
         release_record = self.read("docs/release-v0.3.0-alpha.1.md")
-        self.assertIn("This prerelease is not published", release_record)
-        self.assertIn("must be marked as a prerelease, not latest", release_record)
+        self.assertIn("This prerelease was published on 2026-08-01", release_record)
+        self.assertRegex(
+            release_record,
+            r"It does not include an MSIX or another\s+public Windows binary",
+        )
+        self.assertRegex(
+            release_record,
+            r"marks `v0\.3\.0-alpha\.1` as a prerelease, not\s+latest",
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- link and record the published v0.3.0-alpha.1 Mac/Python prerelease
- keep v0.2.0 identified as latest stable
- keep Windows private and Android experimental

## Validation
- full local Python suite: 465 passed, 13 platform skips
- Ruff lint and format checks
- release copy, version, integrity, and privacy checks
- git diff --check
- hosted matrix: 15/15 passed on exact SHA `1c9734c`