### PR TITLE
Fix Windows recovery finalization and packaged app startup

### DIFF
--- a/.github/workflows/windows-alpha.yml
+++ b/.github/workflows/windows-alpha.yml
@@ -85,14 +85,24 @@ jobs:
           Start-Process explorer.exe `
             "shell:AppsFolder\$($package[0].PackageFamilyName)!App"
           $process = $null
-          for ($attempt = 0; $attempt -lt 30 -and $null -eq $process; $attempt++) {
+          for ($attempt = 0; $attempt -lt 30; $attempt++) {
             Start-Sleep -Milliseconds 500
-            $process = Get-Process -Name "TVTimeRecovery.Windows" -ErrorAction SilentlyContinue
+            $process = Get-Process -Name "TVTimeRecovery.Windows" `
+              -ErrorAction SilentlyContinue | Select-Object -First 1
+            if ($null -ne $process -and $process.MainWindowHandle -ne 0) {
+              break
+            }
           }
-          if ($null -eq $process) {
-            throw "The installed Windows alpha did not remain running for launch smoke."
+          if ($null -eq $process -or $process.MainWindowHandle -eq 0) {
+            throw "The installed Windows alpha did not open an application window."
           }
-          $process | Stop-Process -Force
+          $processId = $process.Id
+          Start-Sleep -Seconds 5
+          $process = Get-Process -Id $processId -ErrorAction SilentlyContinue
+          if ($null -eq $process -or $process.MainWindowHandle -eq 0 -or -not $process.Responding) {
+            throw "The installed Windows alpha did not remain open and responsive."
+          }
+          Stop-Process -Id $processId -Force
       - name: Remove the Windows alpha and certificate
         if: always()
         shell: powershell

--- a/tests/test_android_acquisition.py
+++ b/tests/test_android_acquisition.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import csv
 import io
+import os
 import sqlite3
 import stat
 import tempfile
@@ -100,7 +101,7 @@ class AndroidAcquisitionTests(unittest.TestCase):
         metadata.assert_called_once_with(source)
 
     def test_snapshot_selection_uses_protected_optional_file_opens(self) -> None:
-        root = Path("/synthetic-snapshot")
+        root = Path(Path.cwd().anchor) / "synthetic-snapshot"
         selected = root / "databases" / "DioCache.db"
 
         def protect(candidate: Path, *, volume_already_validated: bool) -> Path | None:
@@ -283,6 +284,7 @@ class AndroidAcquisitionTests(unittest.TestCase):
             self.assertNotIn(target, [Path(database) for database in opened[1:]])
             self.assertGreater(target.stat().st_size, 0)
 
+    @unittest.skipIf(os.name == "nt", "POSIX retained-inode SQLite fallback")
     def test_normalized_official_export_uses_safe_legacy_sqlite_backup(self) -> None:
         class LegacyConnection:
             def __init__(self, connection: sqlite3.Connection) -> None:
@@ -420,6 +422,7 @@ class AndroidAcquisitionTests(unittest.TestCase):
                 [],
             )
 
+    @unittest.skipIf(os.name == "nt", "POSIX live-WAL snapshot regression")
     def test_preserved_snapshot_binds_and_copies_committed_wal_sidecars(self) -> None:
         with tempfile.TemporaryDirectory() as temporary:
             root = Path(temporary)

--- a/tests/test_android_device.py
+++ b/tests/test_android_device.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import stat
 import sys
 import tempfile
 import unittest
@@ -18,6 +19,7 @@ from tvtime_extractor.android_device import (
     probe_android_device,
 )
 from tvtime_extractor.errors import TVTimeError, UserInputError
+from tvtime_extractor.safety import require_private_path
 
 
 class _SyntheticADB:
@@ -249,7 +251,10 @@ class AndroidCapabilityProbeTests(unittest.TestCase):
             )
             self.assertEqual(result.android_backup_version, 5)
             self.assertTrue(destination.is_file())
-            self.assertEqual(destination.stat().st_mode & 0o077, 0)
+            if os.name == "nt":
+                require_private_path(destination, expected_type=stat.S_IFREG)
+            else:
+                self.assertEqual(destination.stat().st_mode & 0o077, 0)
 
     @unittest.skipIf(os.name == "nt", "POSIX descriptor-alias regression")
     def test_capture_path_substitution_cannot_redirect_adb_bytes(self) -> None:

--- a/tests/test_safety_windows.py
+++ b/tests/test_safety_windows.py
@@ -64,6 +64,7 @@ from tvtime_extractor.safety import (
     private_temporary_directory,
     read_regular_bytes,
     regular_binary_reader,
+    remove_empty_private_directory,
     require_encrypted_ios_source_platform_support,
     secure_directory,
     secure_file,
@@ -575,6 +576,131 @@ class WindowsDirectoryHandleContractTests(unittest.TestCase):
                     staged_path = staging
                     (staging / "synthetic.sqlite").write_bytes(b"synthetic")
                 self.assertFalse(staged_path.exists())
+
+    def test_bound_empty_directory_is_deleted_through_its_exact_handle(self) -> None:
+        root = self._synthetic_absolute_path("Synthetic", "Private")
+        temporary = root / ".tmp"
+        identity = (7, 13)
+        state = _WindowsBoundOutputState(
+            handle=100,
+            identity=(7, 11),
+            visible_root=root,
+            descendant_handles={
+                _casefolded_path(temporary): (temporary, 101, identity),
+            },
+        )
+        token = _WINDOWS_BOUND_OUTPUT_STATE.set(state)
+        try:
+            with (
+                mock.patch("tvtime_extractor.safety._running_on_windows", return_value=True),
+                mock.patch(
+                    "tvtime_extractor.safety.no_link_absolute_path",
+                    return_value=temporary,
+                ),
+                mock.patch(
+                    "tvtime_extractor.safety._windows_directory_identity",
+                    return_value=identity,
+                ),
+                mock.patch(
+                    "tvtime_extractor.safety._require_windows_visible_directory_identity"
+                ) as visible,
+                mock.patch("tvtime_extractor.safety._windows_require_private_acl") as require_acl,
+                mock.patch(
+                    "tvtime_extractor.safety._windows_native.delete_empty_directory"
+                ) as delete,
+                mock.patch("tvtime_extractor.safety._windows_close_handle") as close,
+                mock.patch("tvtime_extractor.safety.recovery_path_exists", return_value=False),
+            ):
+                remove_empty_private_directory(temporary)
+        finally:
+            _WINDOWS_BOUND_OUTPUT_STATE.reset(token)
+
+        visible.assert_called_once_with(temporary, expected_identity=identity)
+        require_acl.assert_called_once_with(101)
+        delete.assert_called_once_with(101)
+        close.assert_called_once_with(101)
+        self.assertNotIn(_casefolded_path(temporary), state.descendant_handles)
+
+    def test_failed_empty_directory_deletion_keeps_the_bound_capability(self) -> None:
+        root = self._synthetic_absolute_path("Synthetic", "Private")
+        temporary = root / ".tmp"
+        identity = (7, 13)
+        key = _casefolded_path(temporary)
+        state = _WindowsBoundOutputState(
+            handle=100,
+            identity=(7, 11),
+            visible_root=root,
+            descendant_handles={key: (temporary, 101, identity)},
+        )
+        token = _WINDOWS_BOUND_OUTPUT_STATE.set(state)
+        try:
+            with (
+                mock.patch("tvtime_extractor.safety._running_on_windows", return_value=True),
+                mock.patch(
+                    "tvtime_extractor.safety.no_link_absolute_path",
+                    return_value=temporary,
+                ),
+                mock.patch(
+                    "tvtime_extractor.safety._windows_directory_identity",
+                    return_value=identity,
+                ),
+                mock.patch("tvtime_extractor.safety._require_windows_visible_directory_identity"),
+                mock.patch("tvtime_extractor.safety._windows_require_private_acl"),
+                mock.patch(
+                    "tvtime_extractor.safety._windows_native.delete_empty_directory",
+                    side_effect=WindowsNativeError("synthetic directory was not empty"),
+                ),
+                mock.patch("tvtime_extractor.safety._windows_close_handle") as close,
+                self.assertRaisesRegex(UnsafePathError, "not empty"),
+            ):
+                remove_empty_private_directory(temporary)
+        finally:
+            _WINDOWS_BOUND_OUTPUT_STATE.reset(token)
+
+        self.assertEqual(state.descendant_handles[key], (temporary, 101, identity))
+        close.assert_not_called()
+
+    def test_existing_extraction_anchor_reuses_an_active_bound_handle(self) -> None:
+        root = self._synthetic_absolute_path("Synthetic", "Private")
+        extraction = root / "TVTime-Extraction"
+        identity = (7, 13)
+        state = _WindowsBoundOutputState(
+            handle=100,
+            identity=(7, 11),
+            visible_root=root,
+            descendant_handles={
+                _casefolded_path(extraction): (extraction, 101, identity),
+            },
+        )
+        token = _WINDOWS_BOUND_OUTPUT_STATE.set(state)
+        try:
+            with (
+                mock.patch("tvtime_extractor.safety._running_on_windows", return_value=True),
+                mock.patch(
+                    "tvtime_extractor.safety.require_local_recovery_source",
+                    return_value=extraction,
+                ),
+                mock.patch(
+                    "tvtime_extractor.safety._windows_directory_identity",
+                    return_value=identity,
+                ),
+                mock.patch("tvtime_extractor.safety._require_windows_visible_directory_identity"),
+                mock.patch("tvtime_extractor.safety._windows_require_private_acl") as require_acl,
+                mock.patch(
+                    "tvtime_extractor.safety._windows_hold_existing_descendant_directories"
+                ) as retain,
+                mock.patch(
+                    "tvtime_extractor.safety._windows_pinned_absolute_directory_handle"
+                ) as reopen,
+                anchored_existing_extraction_root(extraction) as anchored,
+            ):
+                self.assertEqual(anchored, extraction)
+        finally:
+            _WINDOWS_BOUND_OUTPUT_STATE.reset(token)
+
+        require_acl.assert_called_once_with(101)
+        retain.assert_called_once_with(extraction, cancellation_check=None)
+        reopen.assert_not_called()
 
     def test_unanchored_private_temporary_directory_binds_children_to_its_handle(self) -> None:
         parent = Path("C:/Synthetic/Private")
@@ -1103,6 +1229,36 @@ class WindowsDirectoryHandleContractTests(unittest.TestCase):
             replace=False,
         )
         self.assertEqual(closed, [101])
+
+    def test_handle_promotion_reuses_the_bound_destination_parent(self) -> None:
+        root = Path("C:/Synthetic/Private")
+        destination = root / "Analysis"
+        state = _WindowsBoundOutputState(
+            handle=101,
+            identity=(7, 11),
+            visible_root=root,
+        )
+        token = _WINDOWS_BOUND_OUTPUT_STATE.set(state)
+        try:
+            with (
+                mock.patch(
+                    "tvtime_extractor.safety._windows_directory_identity",
+                    return_value=(7, 11),
+                ),
+                mock.patch("tvtime_extractor.safety._require_windows_visible_directory_identity"),
+                mock.patch("tvtime_extractor.safety._windows_open_locked_directory") as open_parent,
+                mock.patch(
+                    "tvtime_extractor.safety._windows_native.rename_handle_relative"
+                ) as rename,
+                mock.patch("tvtime_extractor.safety._windows_close_handle") as close,
+            ):
+                _windows_rename_handle_no_replace(202, destination)
+        finally:
+            _WINDOWS_BOUND_OUTPUT_STATE.reset(token)
+
+        open_parent.assert_not_called()
+        rename.assert_called_once_with(202, 101, ("Analysis",), replace=False)
+        close.assert_not_called()
 
     def test_parent_promotion_suspends_and_rebinds_child_capabilities(self) -> None:
         root = Path("/synthetic/private")

--- a/tests/test_windows_license_collection.py
+++ b/tests/test_windows_license_collection.py
@@ -175,7 +175,7 @@ class WindowsLicenseCollectionTests(unittest.TestCase):
             json.dumps({"version": 2, "contentHash": content_hash, "source": "synthetic"}),
             encoding="utf-8",
         )
-        (package_root / "fake.package.nuspec").write_text(nuspec, encoding="utf-8")
+        (package_root / "fake.package.nuspec").write_bytes(nuspec.encode("utf-8"))
         expanded = package_root / "lib" / "net8.0" / "synthetic.dll"
         expanded.parent.mkdir(parents=True)
         expanded.write_bytes(expanded_asset)
@@ -334,14 +334,10 @@ class WindowsLicenseCollectionTests(unittest.TestCase):
                 json.dumps({"version": 2, "contentHash": content_hash}),
                 encoding="utf-8",
             )
-            (package_root / f"{name}.nuspec").write_text(nuspec, encoding="utf-8")
-            (package_root / "LICENSE.TXT").write_text(
-                "Synthetic runtime license\n",
-                encoding="ascii",
-            )
-            (package_root / "THIRD-PARTY-NOTICES.TXT").write_text(
-                "Synthetic runtime notices\n",
-                encoding="ascii",
+            (package_root / f"{name}.nuspec").write_bytes(nuspec.encode("utf-8"))
+            (package_root / "LICENSE.TXT").write_bytes(b"Synthetic runtime license\n")
+            (package_root / "THIRD-PARTY-NOTICES.TXT").write_bytes(
+                b"Synthetic runtime notices\n"
             )
             expanded = package_root / "runtimes" / "win-x64" / "lib" / "net8.0"
             expanded.mkdir(parents=True)

--- a/tests/test_windows_license_collection.py
+++ b/tests/test_windows_license_collection.py
@@ -336,9 +336,7 @@ class WindowsLicenseCollectionTests(unittest.TestCase):
             )
             (package_root / f"{name}.nuspec").write_bytes(nuspec.encode("utf-8"))
             (package_root / "LICENSE.TXT").write_bytes(b"Synthetic runtime license\n")
-            (package_root / "THIRD-PARTY-NOTICES.TXT").write_bytes(
-                b"Synthetic runtime notices\n"
-            )
+            (package_root / "THIRD-PARTY-NOTICES.TXT").write_bytes(b"Synthetic runtime notices\n")
             expanded = package_root / "runtimes" / "win-x64" / "lib" / "net8.0"
             expanded.mkdir(parents=True)
             (expanded / "synthetic.dll").write_bytes(runtime_asset)

--- a/tests/test_windows_native.py
+++ b/tests/test_windows_native.py
@@ -799,6 +799,48 @@ class WindowsNativeUnitTests(unittest.TestCase):
             [True, False, True, False],
         )
 
+    def test_empty_directory_cleanup_refuses_contents_before_disposition(self) -> None:
+        information = windows_native.WindowsHandleInformation(
+            attributes=windows_native.FILE_ATTRIBUTE_DIRECTORY,
+            identity=(7, 10),
+            byte_size=0,
+            last_write_time=19,
+        )
+        entry = windows_native.WindowsDirectoryEntryInformation(
+            name="unexpected.bin",
+            attributes=windows_native.FILE_ATTRIBUTE_NORMAL,
+            identity=(7, 11),
+            byte_size=9,
+            last_write_time=19,
+            last_access_time=17,
+            short_name=None,
+        )
+        with (
+            mock.patch.object(windows_native, "handle_information", return_value=information),
+            mock.patch.object(windows_native, "directory_entries", return_value=(entry,)),
+            mock.patch.object(windows_native, "_mark_handle_for_deletion") as mark,
+            self.assertRaisesRegex(windows_native.WindowsNativeError, "not empty"),
+        ):
+            windows_native.delete_empty_directory(100)
+
+        mark.assert_not_called()
+
+    def test_empty_directory_cleanup_marks_the_exact_handle_for_deletion(self) -> None:
+        information = windows_native.WindowsHandleInformation(
+            attributes=windows_native.FILE_ATTRIBUTE_DIRECTORY,
+            identity=(7, 10),
+            byte_size=0,
+            last_write_time=19,
+        )
+        with (
+            mock.patch.object(windows_native, "handle_information", return_value=information),
+            mock.patch.object(windows_native, "directory_entries", return_value=()),
+            mock.patch.object(windows_native, "_mark_handle_for_deletion") as mark,
+        ):
+            windows_native.delete_empty_directory(100)
+
+        mark.assert_called_once_with(100)
+
     def test_cleanup_child_handle_blocks_rename_and_opens_the_reparse_itself(self) -> None:
         information = windows_native.WindowsHandleInformation(
             attributes=(

--- a/tvtime_extractor/acquisition.py
+++ b/tvtime_extractor/acquisition.py
@@ -48,6 +48,7 @@ from .safety import (
     no_link_absolute_path,
     optional_local_recovery_regular_file,
     regular_binary_reader,
+    remove_empty_private_directory,
     require_bound_destination_parent,
     require_local_recovery_source,
     require_private_local_destination,
@@ -630,13 +631,7 @@ def _seal_acquisition(
             cancellation_check=cancellation_check,
         ),
     )
-    temporary_root = extraction_root / ".tmp"
-    try:
-        temporary_root.rmdir()
-    except OSError as exc:
-        raise UnsafePathError(
-            "The private acquisition staging directory was not empty at completion."
-        ) from exc
+    remove_empty_private_directory(extraction_root / ".tmp")
     return ExtractionResult(extraction_root=extraction_root, summary=summary)
 
 

--- a/tvtime_extractor/safety.py
+++ b/tvtime_extractor/safety.py
@@ -1391,11 +1391,17 @@ def _windows_rename_handle_no_replace(
     """Rename one exact Windows file or directory handle without replacement."""
 
     parent_handle = -1
+    parent_owned = False
     try:
-        parent_handle, _parent_identity = _windows_open_locked_directory(
-            destination.parent,
-            allow_child_creation=True,
-        )
+        parent_binding = _windows_bound_directory_binding(destination.parent)
+        if parent_binding is not None:
+            _parent_visible, parent_handle, _parent_identity = parent_binding
+        else:
+            parent_handle, _parent_identity = _windows_open_locked_directory(
+                destination.parent,
+                allow_child_creation=True,
+            )
+            parent_owned = True
         try:
             _windows_native.rename_handle_relative(
                 native_handle,
@@ -1410,7 +1416,8 @@ def _windows_rename_handle_no_replace(
         except _windows_native.WindowsNativeError as exc:
             raise UnsafePathError("The private Windows file could not be promoted safely.") from exc
     finally:
-        _windows_close_handles((parent_handle,))
+        if parent_owned:
+            _windows_close_handles((parent_handle,))
 
 
 def _windows_promote_held_file_no_replace(
@@ -2068,6 +2075,51 @@ def _windows_delete_private_tree_handle(
         _windows_close_handles((handle,))
     if recovery_path_exists(path):
         raise UnsafePathError("A private Windows temporary directory remained after cleanup.")
+
+
+def remove_empty_private_directory(path: Path) -> None:
+    """Remove one exact private directory, refusing any unexpected contents."""
+
+    candidate = no_link_absolute_path(path)
+    if _running_on_windows():
+        state = _WINDOWS_BOUND_OUTPUT_STATE.get()
+        if state is None:
+            raise UnsafePathError("A trusted Windows output-root handle was not active.")
+        key = _casefolded_path(candidate)
+        entry = state.descendant_handles.get(key)
+        if entry is None:
+            raise UnsafePathError("A private Windows temporary directory handle was unavailable.")
+        for other_key, (
+            other_visible,
+            _other_handle,
+            _other_identity,
+        ) in state.descendant_handles.items():
+            if other_key != key and _is_within_casefolded(other_visible, candidate):
+                raise UnsafePathError(
+                    "A temporary Windows recovery directory still retained a child capability."
+                )
+        visible, handle, identity = entry
+        if _windows_directory_identity(handle) != identity:
+            raise UnsafePathError("A private Windows temporary directory identity changed.")
+        _windows_require_private_acl(handle)
+        _require_windows_visible_directory_identity(visible, expected_identity=identity)
+        try:
+            _windows_native.delete_empty_directory(handle)
+        except _windows_native.WindowsNativeError as exc:
+            raise UnsafePathError(
+                "The private temporary directory was not empty at completion."
+            ) from exc
+        state.descendant_handles.pop(key)
+        _windows_close_handle(handle)
+        if recovery_path_exists(candidate):
+            raise UnsafePathError("The private temporary directory remained after safe removal.")
+        return
+    try:
+        candidate.rmdir()
+    except OSError as exc:
+        raise UnsafePathError(
+            "The private temporary directory was not empty at completion."
+        ) from exc
 
 
 def windows_delete_bound_private_tree(path: Path) -> None:
@@ -2761,6 +2813,26 @@ def anchored_existing_extraction_root(
 
     visible_root = require_local_recovery_source(extraction_root)
     if _running_on_windows():
+        existing_binding = _windows_bound_directory_binding(visible_root)
+        if existing_binding is not None:
+            _visible, root_handle, root_identity = existing_binding
+            _windows_require_private_acl(root_handle)
+            _windows_hold_existing_descendant_directories(
+                visible_root,
+                cancellation_check=cancellation_check,
+            )
+            try:
+                yield visible_root
+            finally:
+                if _windows_directory_identity(root_handle) != root_identity:
+                    raise UnsafePathError(
+                        "The trusted Windows extraction-root handle identity changed."
+                    )
+                _require_visible_existing_directory_identity(
+                    visible_root,
+                    expected_identity=root_identity,
+                )
+            return
         token = None
         root_identity = (0, 0)
         windows_state: _WindowsBoundOutputState | None = None

--- a/tvtime_extractor/windows_native.py
+++ b/tvtime_extractor/windows_native.py
@@ -1332,6 +1332,24 @@ def _mark_handle_for_deletion(handle: int) -> None:
         raise _last_error("A private Windows temporary entry could not be removed safely.")
 
 
+def delete_empty_directory(handle: int) -> None:
+    """Delete one exact held directory only when it is already empty."""
+
+    information = handle_information(handle)
+    if (
+        not information.is_directory
+        or information.is_reparse_point
+        or information.is_cloud_hydrated
+    ):
+        raise WindowsNativeError("A private Windows temporary directory was unsafe.")
+    if directory_entries(handle):
+        raise WindowsNativeError("A private Windows temporary directory was not empty.")
+    # SetFileInformationByHandle applies to this exact directory identity. If a
+    # concurrent writer creates an entry after the enumeration, Windows rejects
+    # the disposition rather than deleting a non-empty directory.
+    _mark_handle_for_deletion(handle)
+
+
 def delete_private_tree(root_handle: int) -> None:
     """Delete one exact held tree without performing a destructive path reopen."""
 

--- a/windows/TVTimeRecovery.Windows/App.xaml
+++ b/windows/TVTimeRecovery.Windows/App.xaml
@@ -2,5 +2,11 @@
   x:Class="TVTimeRecovery.Windows.App"
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
-  <Application.Resources />
+  <Application.Resources>
+    <ResourceDictionary>
+      <ResourceDictionary.MergedDictionaries>
+        <XamlControlsResources xmlns="using:Microsoft.UI.Xaml.Controls" />
+      </ResourceDictionary.MergedDictionaries>
+    </ResourceDictionary>
+  </Application.Resources>
 </Application>


### PR DESCRIPTION
## Summary
- make Android archive, preserved-snapshot, and official-export recovery complete safely on Windows by deleting the private staging directory through its retained Win32 capability
- reuse existing Windows directory capabilities during analysis and no-clobber promotion instead of opening conflicting handles
- load WinUI control resources so the packaged app opens instead of crashing in Microsoft.UI.Xaml.dll with 0xc000027b
- harden the Windows artifact smoke test to require a real, responsive window that remains alive
- make NuGet license fixtures byte-stable and formatter-stable across Windows/Linux checkouts

## Confirmed Windows dogfood
- reproduced the old downloadable artifact crash at commit 512d25a after verified install; Windows Application Error identified Microsoft.UI.Xaml.dll / 0xc000027b
- installed public CLI recovered synthetic Android compressed backup, preserved Android snapshot, and official export; independent output validation and privacy scrub passed
- final branch rebased onto current `origin/main` (`7ffbcaf`); final commit is `99cb876`, with reviewed source tree `fa8daaf`
- downloaded the exact GitHub Actions artifact for `99cb876`; outer ZIP SHA-256 and all eight manifest-bound internal file hashes/sizes passed
- verified the MSIX signature as Valid with the exact manifest certificate thumbprint
- installed the downloaded MSIX on a physical Windows machine; its `TV Time Backup Extractor` window had a real handle, remained alive, and was responsive after 8 seconds
- removed the test package and exact temporary certificate; zero package, certificate, or process residue remained

## Test evidence
- final GitHub CI is green, including Windows existing-extraction/native filesystem tests on Python 3.10, 3.11, 3.12, and 3.13
- final source-bound Windows package workflow is green, including package install, stable responsive window, cleanup, ZIP reverification, and artifact upload
- local focused Windows/Android/security/release run: 176 passed, 4 intentional platform skips
- Release x64 WinUI build: 0 warnings, 0 errors
- Windows packaging identity/cleanup and MSIX capability/digest checks passed
- Ruff lint/format and Git diff checks passed

## Environment limits
The physical test machine has BitLocker protection off, so native recovery correctly refuses real sensitive backup data under the project's safety policy. Synthetic CLI recovery and the exact downloadable packaged-app startup are confirmed. No physical Android device or emulator was attached, so device transport itself remains untested here.